### PR TITLE
Fix the link to Web / Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A curated list of awesome Haskell frameworks, libraries and software. Inspired b
     - [Graphics](#graphics)
     - [Network](#network)
     - [Number Theory](#number-theory)
-    - [Web / Frameworks](#web-frameworks)
+    - [Web / Frameworks](#web--frameworks)
     - [Text Processing](#text-processing)
     - [Messaging](#messaging)
     - [Languages](#languages)


### PR DESCRIPTION
Because of the '/' in the title, another hyphen is needed for it to make the jump correctly.
