### PR TITLE
Add m2cgen for transpiling ML models into Haskell

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,10 @@ An auxiliary list of awesome Haskell links, frameworks, libraries and software. 
 * [Text Recognition](http://hackage.haskell.org/packages/#cat:Text%20Recognition) - a collaborative Hackage list.
 * [Robotics](http://hackage.haskell.org/packages/#cat:Robotics) - a collaborative Hackage list.
 
+    ---
+*Additional libraries*
+* [m2cgen](https://github.com/BayesWitnesses/m2cgen) - A CLI tool to transpile trained classic ML models into a native Haskell code with zero dependencies.
+
 ## Data Structures
 * [Data Structures & IO Libraries](https://wiki.haskell.org/Applications_and_libraries/Data_structures) - Official Website Resources.
 


### PR DESCRIPTION
`m2cgen` is a lightweight library with command line interface which allows to transpile trained machine learning models into a native code of Haskell programming language. Examples of generated Haskell code can be found [here](https://github.com/BayesWitnesses/m2cgen/tree/master/generated_code_examples/haskell).