### PR TITLE
replaced Haskell Platform with GHCup

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ An auxiliary list of awesome Haskell links, frameworks, libraries and software. 
 * [Cabal](https://www.haskell.org/cabal/) - a system for building and packaging Haskell libraries and programs.
 * [GHC](https://www.haskell.org/ghc/) - the state-of-the-art optimizing native code compiler for Haskell.
 * [GHCi](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/ghci.html) - a bytecode interpreter and interactive REPL environment for Haskell.
+* [GHCup](https://www.haskell.org/ghcup) - GHCup is the main installer for the general purpose language Haskell.
 * [Hackage](http://hackage.haskell.org/) - the Haskell community's central package archive.
 * [Haddock](https://www.haskell.org/haddock/) - a tool for automatically generating documentation from annotated Haskell source code.
 * [Happy](https://www.haskell.org/happy/) - The Parser Generator for Haskell.
@@ -61,7 +62,6 @@ An auxiliary list of awesome Haskell links, frameworks, libraries and software. 
 * [hsenv](https://github.com/Paczesiowa/hsenv/) - a tool to create isolated Haskell environments. This allows a project to use a GHC version different of the currently installed.
 * [Stack](https://github.com/commercialhaskell/stack) - a cross-platform tool to help on building Haskell projects. It includes support to create isolated Haskell environments and to automatically manage the dependencies of a project.
 * [Stackage](https://github.com/fpco/stackage) - "Stable Hackage," tools for creating a vetted set of packages from Hackage.
-* [The Haskell Platform](https://www.haskell.org/platform/contents.html) - a comprehensive, robust development environment for programming in Haskell.
 
 ## Algorithmics
 


### PR DESCRIPTION
Haskell Platform is no longer available (error 404). Haskell main page now points to GHCup.