### PR TITLE
Add a2ml-haskell and k9-haskell to Data Formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,9 @@ An auxiliary list of awesome Haskell links, frameworks, libraries and software. 
 
 ## Data Formats
 
+* [a2ml-haskell](https://github.com/hyperpolymath/a2ml-haskell) - Parser and renderer for A2ML (Attested Markup Language) - AI agent identity and attestation format.
 * [JSON](http://hackage.haskell.org/packages/#cat:JSON) - a collaborative Hackage list.
+* [k9-haskell](https://github.com/hyperpolymath/k9-haskell) - Parser and renderer for K9 (Self-Validating Components) - configuration with Nickel contracts and trust levels.
 * [PDF](http://hackage.haskell.org/packages/#cat:PDF) - a collaborative Hackage list.
 * [XML](http://hackage.haskell.org/packages/#cat:XML) - a collaborative Hackage list.
 * [RSS](http://hackage.haskell.org/packages/#cat:RSS) - a collaborative Hackage list.


### PR DESCRIPTION
Adds two Haskell parser/renderer libraries to the **Data Formats** section (in alphabetical order):

- **[a2ml-haskell](https://github.com/hyperpolymath/a2ml-haskell)** — Parser and renderer for A2ML (Attested Markup Language), a format for AI agent identity and attestation.
- **[k9-haskell](https://github.com/hyperpolymath/k9-haskell)** — Parser and renderer for K9 (Self-Validating Components), a configuration format using Nickel contracts and trust levels.

Both are Hackage-ready libraries with full parsing and rendering support.