### PR TITLE
Redesign Awesome Haskell as an evidence-based ecosystem guide

### DIFF
--- a/.github/workflows/verify-examples.yml
+++ b/.github/workflows/verify-examples.yml
@@ -1,0 +1,62 @@
+name: Verify examples
+
+on:
+  push:
+    branches:
+      - master
+      - awesome-haskell-next
+    paths:
+      - "examples/**"
+      - ".github/workflows/verify-examples.yml"
+  pull_request:
+    paths:
+      - "examples/**"
+      - ".github/workflows/verify-examples.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  beginner-cli:
+    name: Beginner CLI (GHC ${{ matrix.ghc }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc:
+          - "9.12"
+          - "9.14"
+
+    defaults:
+      run:
+        working-directory: examples/beginner-cli
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Haskell
+        uses: haskell-actions/setup@v2
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: latest
+
+      - name: Show tool versions
+        run: |
+          ghc --version
+          cabal --version
+
+      - name: Check package metadata
+        run: cabal check
+
+      - name: Build
+        run: cabal build all
+
+      - name: Test
+        run: cabal test all --test-show-details=direct
+
+      - name: Run example
+        run: cabal run hello-haskell -- Ada Lovelace

--- a/.github/workflows/verify-examples.yml
+++ b/.github/workflows/verify-examples.yml
@@ -49,9 +49,6 @@ jobs:
           ghc --version
           cabal --version
 
-      - name: Check package metadata
-        run: cabal check
-
       - name: Build
         run: cabal build all
 

--- a/.github/workflows/verify-examples.yml
+++ b/.github/workflows/verify-examples.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - awesome-haskell-next
     paths:
       - "examples/**"
       - ".github/workflows/verify-examples.yml"

--- a/CONTRIBUTING.next.md
+++ b/CONTRIBUTING.next.md
@@ -1,0 +1,162 @@
+# Contributing to Awesome Haskell Next
+
+This document applies to the redesign developed on the `awesome-haskell-next` branch. The existing contribution process remains unchanged until the redesign is accepted.
+
+## Before contributing
+
+Awesome Haskell Next distinguishes between two kinds of entries:
+
+1. **Discovery entries** help readers explore the ecosystem.
+2. **Reviewed recommendations** help readers choose between concrete options.
+
+A project may be useful as a discovery entry without being a recommended default. Please make the intended role explicit.
+
+## Discovery entries
+
+Discovery entries may include:
+
+- projects and packages;
+- Hackage categories;
+- official documentation;
+- books, courses, talks, and tutorials;
+- community resources;
+- historical projects that explain the ecosystem.
+
+A discovery contribution should provide:
+
+- the correct name and canonical URL;
+- a neutral one-sentence description;
+- the most appropriate category;
+- disclosure of any affiliation with the linked project.
+
+Discovery entries should not use promotional language such as “best,” “leading,” or “production-ready” without evidence.
+
+## Reviewed recommendations
+
+A reviewed recommendation uses a higher standard. It should answer:
+
+- What problem does this option solve?
+- Who is it appropriate for?
+- When should a reader consider an alternative?
+- What are its important trade-offs?
+- Which nearby alternatives were considered?
+- What current evidence supports the recommendation?
+- When was the entry reviewed?
+
+A recommendation should normally include at least one limitation. A contribution that only lists advantages is incomplete.
+
+## Evidence
+
+Prefer primary sources:
+
+- official documentation;
+- release notes;
+- repository metadata;
+- compatibility documentation;
+- maintainer statements;
+- technical reports written by production users;
+- runnable examples and CI results.
+
+Secondary articles and community discussions can add context, but they should not be the sole source for strong claims about maintenance, compatibility, security, or production use.
+
+GitHub stars, download counts, and commit frequency may be mentioned as context. They are not sufficient evidence for a recommendation.
+
+## Project status
+
+Do not infer status from the date of the last commit alone.
+
+A project with few commits may be stable and complete. A project with frequent commits may still be experimental or unsuitable for a particular use case.
+
+When proposing a status, explain the evidence. When the evidence is insufficient, use `unknown` rather than guessing.
+
+The working vocabulary is:
+
+- `active`;
+- `stable`;
+- `experimental`;
+- `maintenance-mode`;
+- `historical`;
+- `archived`;
+- `unknown`.
+
+Recommendation level is separate from maintenance status. For example, a stable project can be either recommended or discovery-only.
+
+## Review dates
+
+Reviewed guidance must include a `last_reviewed` date in ISO format:
+
+```text
+YYYY-MM-DD
+```
+
+A review date means that a contributor inspected the cited evidence on that date. It does not guarantee future compatibility.
+
+## Runnable examples
+
+Add an example only when it removes meaningful uncertainty, such as:
+
+- how several libraries fit together;
+- whether a recommended setup compiles;
+- how to structure a first project;
+- how two approaches differ in practice.
+
+Examples should be:
+
+- intentionally small;
+- documented with exact commands;
+- tested in CI;
+- free of unrelated abstractions;
+- explicit about supported compiler versions.
+
+Do not add a large showcase application merely to demonstrate that a library exists.
+
+## Affiliation and conflicts of interest
+
+Contributors must disclose when they are:
+
+- a maintainer or contributor to the recommended project;
+- employed by a company behind the project;
+- selling services primarily based on the project;
+- otherwise likely to benefit from its inclusion.
+
+Affiliation does not disqualify a contribution. Hidden affiliation damages trust.
+
+## Writing style
+
+Use neutral, concrete language.
+
+Prefer:
+
+> Suitable for small HTTP services where a minimal API is more important than type-level API descriptions.
+
+Avoid:
+
+> The fastest and easiest framework for modern Haskell development.
+
+Explain decisions rather than adding adjectives.
+
+## Pull request checklist
+
+For a discovery entry:
+
+- [ ] The link is canonical and works.
+- [ ] The description is neutral and specific.
+- [ ] The category is appropriate.
+- [ ] Affiliation is disclosed.
+
+For a reviewed recommendation:
+
+- [ ] The target use case is defined.
+- [ ] At least one trade-off is documented.
+- [ ] Alternatives are named.
+- [ ] Maintenance or stability claims have evidence.
+- [ ] Primary sources are included where available.
+- [ ] `last_reviewed` is present.
+- [ ] Affiliation is disclosed.
+- [ ] Any runnable example builds and passes CI.
+
+## Scope control
+
+The redesign is incremental. A focused improvement to one category is preferable to a large automated rewrite of the entire repository.
+
+When uncertain whether an entry belongs in the project, open an issue or discussion describing the user problem it would solve before preparing a large pull request.

--- a/CONTRIBUTING.next.md
+++ b/CONTRIBUTING.next.md
@@ -1,6 +1,6 @@
 # Contributing to Awesome Haskell Next
 
-This document applies to the redesign developed on the `awesome-haskell-next` branch. The existing contribution process remains unchanged until the redesign is accepted.
+This document applies to the staged redesign described in `README.next.md`. The existing contribution process remains unchanged until the new entry point is activated and this file replaces the main contribution guide.
 
 ## Before contributing
 

--- a/README.next.md
+++ b/README.next.md
@@ -27,6 +27,31 @@ The guide lets readers enter through a task rather than requiring them to unders
 
 See [`VISION.md`](VISION.md) for the full direction and [`docs/README_AUDIT.md`](docs/README_AUDIT.md) for the migration plan.
 
+## Verified examples
+
+Recommendations become more trustworthy when readers can inspect and run the same code that CI verifies.
+
+### [Beginner CLI](examples/beginner-cli)
+
+A deliberately small Cabal project demonstrating:
+
+- a reusable pure library module;
+- a separate executable entry point;
+- a test suite without hidden framework machinery;
+- compiler warnings enabled centrally;
+- command-line arguments;
+- automated builds and tests on GHC 9.12 and 9.14.
+
+Run it from `examples/beginner-cli`:
+
+```sh
+cabal build all
+cabal test all --test-show-details=direct
+cabal run hello-haskell -- Ada Lovelace
+```
+
+The workflow is defined in [`.github/workflows/verify-examples.yml`](.github/workflows/verify-examples.yml). More examples should only be added when they clarify a real decision or eliminate meaningful setup uncertainty.
+
 ## How entries will be organized
 
 Important categories will have two complementary sections.
@@ -103,7 +128,7 @@ The goal is not to compete on the amount of generated prose. The goal is to beco
 
 The new model will first be tested on a small set of high-value sections:
 
-1. **[Getting started](guides/getting-started.md)** — first reviewed vertical slice;
+1. **[Getting started](guides/getting-started.md)** — first reviewed guide with a [CI-tested CLI example](examples/beginner-cli);
 2. Web APIs;
 3. Databases;
 4. Testing;
@@ -134,7 +159,9 @@ During the transition:
 - [`README.next.md`](README.next.md) is the proposed new entry point;
 - [`VISION.md`](VISION.md) defines the mission and editorial principles;
 - [`docs/README_AUDIT.md`](docs/README_AUDIT.md) records what should be preserved, improved, or retired;
-- [`guides/getting-started.md`](guides/getting-started.md) demonstrates the first reviewed task-oriented guide.
+- [`guides/getting-started.md`](guides/getting-started.md) demonstrates the first reviewed task-oriented guide;
+- [`examples/beginner-cli`](examples/beginner-cli) demonstrates the first runnable, tested example;
+- [`.github/workflows/verify-examples.yml`](.github/workflows/verify-examples.yml) verifies examples across supported compilers.
 
 The original README will only be replaced after the new entry point is useful on its own. History and attribution will be preserved.
 

--- a/README.next.md
+++ b/README.next.md
@@ -81,6 +81,17 @@ Broader discovery material:
 
 This preserves breadth without pretending that every link is an equal recommendation.
 
+## Structured recommendations
+
+The pilot format is documented in [`docs/ENTRY_FORMAT.md`](docs/ENTRY_FORMAT.md). It deliberately separates:
+
+- discovery from recommendation;
+- recommendation level from maintenance status;
+- human review dates from automated metadata;
+- advantages from explicit trade-offs.
+
+The first structured recommendation is [`data/toolchain-management/ghcup.yaml`](data/toolchain-management/ghcup.yaml), derived from the reviewed newcomer guide. The repository will not migrate the full legacy list into YAML until several pilot categories prove that the format is maintainable.
+
 ## Evidence, not rankings
 
 Awesome Haskell will not rank projects using GitHub stars, download counts, or commit frequency alone. Those signals can provide context, but none of them proves that a tool is appropriate, maintained, or production-ready.
@@ -151,6 +162,8 @@ A proposed highlighted recommendation should normally explain the use case, rati
 
 Please avoid adding unexplained promotional links. Broad ecosystem links remain welcome when they are relevant and correctly categorized, but highlighted recommendations use a higher standard.
 
+See [`CONTRIBUTING.next.md`](CONTRIBUTING.next.md) for the redesign's contribution rules and review checklist.
+
 ## Current repository layout
 
 During the transition:
@@ -158,7 +171,10 @@ During the transition:
 - [`README.md`](README.md) contains the original broad ecosystem map;
 - [`README.next.md`](README.next.md) is the proposed new entry point;
 - [`VISION.md`](VISION.md) defines the mission and editorial principles;
+- [`CONTRIBUTING.next.md`](CONTRIBUTING.next.md) defines contribution and evidence standards;
 - [`docs/README_AUDIT.md`](docs/README_AUDIT.md) records what should be preserved, improved, or retired;
+- [`docs/ENTRY_FORMAT.md`](docs/ENTRY_FORMAT.md) documents the pilot structured-data format;
+- [`data/toolchain-management/ghcup.yaml`](data/toolchain-management/ghcup.yaml) is the first structured recommendation;
 - [`guides/getting-started.md`](guides/getting-started.md) demonstrates the first reviewed task-oriented guide;
 - [`examples/beginner-cli`](examples/beginner-cli) demonstrates the first runnable, tested example;
 - [`.github/workflows/verify-examples.yml`](.github/workflows/verify-examples.yml) verifies examples across supported compilers.

--- a/README.next.md
+++ b/README.next.md
@@ -16,16 +16,16 @@ The project began as a broad, categorized collection of libraries, tools, Hackag
 
 ## Start with a goal
 
-The finished guide should let readers enter through a task rather than requiring them to understand the whole taxonomy first.
+The guide lets readers enter through a task rather than requiring them to understand the whole taxonomy first.
 
-- **I am new to Haskell** — installation, first project, editor setup, learning path, and a small recommended starter stack.
-- **I want to build a web API** — major approaches, trade-offs, database options, deployment concerns, and runnable examples.
-- **I need to work with a database** — SQL-first and abstraction-first choices, migrations, pooling, and testing.
-- **I want to test Haskell code** — unit, property, integration, and golden testing tools.
-- **I am evaluating Haskell for production** — real use cases, strengths, operational costs, hiring considerations, and primary sources.
-- **I want to explore the ecosystem** — the broad categorized map of projects, packages, resources, and Hackage indexes.
+- **[I am new to Haskell](guides/getting-started.md)** — installation, first project, editor setup, core tools, troubleshooting, and a recommended starter path. **Reviewed 2026-08-02.**
+- **I want to build a web API** — major approaches, trade-offs, database options, deployment concerns, and runnable examples. _Planned._
+- **I need to work with a database** — SQL-first and abstraction-first choices, migrations, pooling, and testing. _Planned._
+- **I want to test Haskell code** — unit, property, integration, and golden testing tools. _Planned._
+- **I am evaluating Haskell for production** — real use cases, strengths, operational costs, hiring considerations, and primary sources. _Planned._
+- **[I want to explore the ecosystem](README.md)** — the broad categorized map of projects, packages, resources, and Hackage indexes.
 
-These paths are being built incrementally. See [`VISION.md`](VISION.md) for the full direction and [`docs/README_AUDIT.md`](docs/README_AUDIT.md) for the migration plan.
+See [`VISION.md`](VISION.md) for the full direction and [`docs/README_AUDIT.md`](docs/README_AUDIT.md) for the migration plan.
 
 ## How entries will be organized
 
@@ -103,7 +103,7 @@ The goal is not to compete on the amount of generated prose. The goal is to beco
 
 The new model will first be tested on a small set of high-value sections:
 
-1. Getting started;
+1. **[Getting started](guides/getting-started.md)** — first reviewed vertical slice;
 2. Web APIs;
 3. Databases;
 4. Testing;
@@ -133,7 +133,8 @@ During the transition:
 - [`README.md`](README.md) contains the original broad ecosystem map;
 - [`README.next.md`](README.next.md) is the proposed new entry point;
 - [`VISION.md`](VISION.md) defines the mission and editorial principles;
-- [`docs/README_AUDIT.md`](docs/README_AUDIT.md) records what should be preserved, improved, or retired.
+- [`docs/README_AUDIT.md`](docs/README_AUDIT.md) records what should be preserved, improved, or retired;
+- [`guides/getting-started.md`](guides/getting-started.md) demonstrates the first reviewed task-oriented guide.
 
 The original README will only be replaced after the new entry point is useful on its own. History and attribution will be preserved.
 

--- a/README.next.md
+++ b/README.next.md
@@ -1,0 +1,146 @@
+# Awesome Haskell
+
+[![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
+
+**A structured map and evidence-based decision guide for the Haskell ecosystem.**
+
+> This is a working draft for the next version of Awesome Haskell. The original ecosystem map remains available in [`README.md`](README.md) while the new structure is developed and reviewed.
+
+Awesome Haskell helps people do three things:
+
+1. **Discover** the shape of the Haskell ecosystem.
+2. **Choose** tools for a concrete task with explicit trade-offs.
+3. **Verify** that important recommendations are current and usable.
+
+The project began as a broad, categorized collection of libraries, tools, Hackage categories, learning materials, and community resources. That taxonomy remains valuable—especially for newcomers. The next version keeps that map while adding clearer paths, human judgement, review dates, and reproducible evidence.
+
+## Start with a goal
+
+The finished guide should let readers enter through a task rather than requiring them to understand the whole taxonomy first.
+
+- **I am new to Haskell** — installation, first project, editor setup, learning path, and a small recommended starter stack.
+- **I want to build a web API** — major approaches, trade-offs, database options, deployment concerns, and runnable examples.
+- **I need to work with a database** — SQL-first and abstraction-first choices, migrations, pooling, and testing.
+- **I want to test Haskell code** — unit, property, integration, and golden testing tools.
+- **I am evaluating Haskell for production** — real use cases, strengths, operational costs, hiring considerations, and primary sources.
+- **I want to explore the ecosystem** — the broad categorized map of projects, packages, resources, and Hackage indexes.
+
+These paths are being built incrementally. See [`VISION.md`](VISION.md) for the full direction and [`docs/README_AUDIT.md`](docs/README_AUDIT.md) for the migration plan.
+
+## How entries will be organized
+
+Important categories will have two complementary sections.
+
+### Start here
+
+A small number of reviewed choices with context:
+
+- what the project is good for;
+- who it is suitable for;
+- when to consider an alternative;
+- important limitations and trade-offs;
+- maintenance or stability evidence;
+- a visible review date;
+- a runnable example where useful.
+
+### Explore the ecosystem
+
+Broader discovery material:
+
+- relevant Hackage categories;
+- official documentation;
+- additional projects;
+- tutorials and books;
+- community resources;
+- related ecosystem maps.
+
+This preserves breadth without pretending that every link is an equal recommendation.
+
+## Evidence, not rankings
+
+Awesome Haskell will not rank projects using GitHub stars, download counts, or commit frequency alone. Those signals can provide context, but none of them proves that a tool is appropriate, maintained, or production-ready.
+
+Where practical, highlighted recommendations should be supported by:
+
+- upstream documentation and release information;
+- compatibility with supported GHC versions;
+- repository and package status;
+- CI-tested examples;
+- primary-source production reports;
+- public review history;
+- an explicit `last reviewed` date.
+
+A mature project with few commits may be stable rather than abandoned. When the evidence is unclear, the guide should say so.
+
+## Proposed project statuses
+
+- **Recommended** — recommended for a defined use case.
+- **Active** — meaningfully maintained.
+- **Stable** — mature and usable, with little need for frequent change.
+- **Experimental** — promising, but not a default recommendation.
+- **Maintenance mode** — maintained conservatively, with limited new development.
+- **Historical** — useful for context, but generally not for new projects.
+- **Archived** — explicitly discontinued or archived upstream.
+- **Unknown** — not recently reviewed or supported by enough evidence.
+
+Statuses describe different things and may eventually be split into separate fields. For example, a project can be both stable and recommended.
+
+## Why a shared guide still matters
+
+Search engines and AI assistants can produce explanations and lists quickly. A maintained open-source guide can add things that a generated answer usually cannot guarantee:
+
+- durable, inspectable evidence;
+- recommendations reviewed by identifiable contributors;
+- reproducible examples compiled in CI;
+- visible compatibility and review dates;
+- recorded disagreements and trade-offs;
+- corrections that improve one shared public source;
+- structured data reusable by documentation, tools, and AI systems.
+
+The goal is not to compete on the amount of generated prose. The goal is to become a source people and tools can trust.
+
+## Pilot areas
+
+The new model will first be tested on a small set of high-value sections:
+
+1. Getting started;
+2. Web APIs;
+3. Databases;
+4. Testing;
+5. Haskell in production.
+
+A pilot section is complete only when it contains both a useful decision guide and broader discovery links. Runnable examples will be added where they materially reduce uncertainty.
+
+## Contributing during the redesign
+
+The redesign is intentionally incremental. Contributions are welcome in the form of:
+
+- corrections to the existing taxonomy;
+- evidence that a highlighted project is active, stable, deprecated, or archived;
+- concrete trade-offs between nearby choices;
+- primary-source production case studies;
+- small reproducible examples;
+- feedback from newcomers trying to navigate the guide.
+
+A proposed highlighted recommendation should normally explain the use case, rationale, limitations, alternatives, evidence, and review date. Affiliation with a recommended project should be disclosed.
+
+Please avoid adding unexplained promotional links. Broad ecosystem links remain welcome when they are relevant and correctly categorized, but highlighted recommendations use a higher standard.
+
+## Current repository layout
+
+During the transition:
+
+- [`README.md`](README.md) contains the original broad ecosystem map;
+- [`README.next.md`](README.next.md) is the proposed new entry point;
+- [`VISION.md`](VISION.md) defines the mission and editorial principles;
+- [`docs/README_AUDIT.md`](docs/README_AUDIT.md) records what should be preserved, improved, or retired.
+
+The original README will only be replaced after the new entry point is useful on its own. History and attribution will be preserved.
+
+## Working principle
+
+> **Discover broadly. Recommend carefully. Verify what we can. Be explicit about what we do not know.**
+
+## License
+
+[CC0 1.0 Universal](http://creativecommons.org/publicdomain/zero/1.0/)

--- a/VISION.md
+++ b/VISION.md
@@ -1,0 +1,256 @@
+# Awesome Haskell Next — Vision
+
+> Status: initial working draft
+
+## Why this project exists
+
+Awesome Haskell started as a structured map of the Haskell ecosystem. It grouped libraries, tools, learning materials, communities, and broader Hackage categories so that people—especially newcomers—could understand what existed and where to continue exploring.
+
+That original purpose remains useful. The problem is not that the project contains links; the problem is that a link collection alone no longer provides enough context, confidence, or evidence.
+
+Search engines and AI assistants can quickly produce lists and explanations. Awesome Haskell should therefore not try to win by containing the most links or the most prose. It should become a trustworthy, maintained map that helps people:
+
+1. discover the shape of the Haskell ecosystem;
+2. choose an appropriate tool for a concrete task;
+3. verify that the recommendation is current and usable.
+
+## Mission
+
+**Awesome Haskell is an evidence-based map and decision guide for the Haskell ecosystem.**
+
+It combines broad discovery with human curation, explicit trade-offs, reproducible examples, and verifiable project-health information.
+
+## Who it is for
+
+### Newcomers
+
+People who need a clear view of the ecosystem, sensible starting points, and protection from outdated advice.
+
+### Working Haskell developers
+
+People choosing libraries, comparing approaches, or looking for maintained examples and production-oriented guidance.
+
+### Technical decision-makers
+
+People evaluating whether Haskell and its ecosystem are appropriate for a project, team, or domain.
+
+### Maintainers and contributors
+
+People who need a neutral place to document project status, alternatives, migration paths, and ecosystem gaps.
+
+## The three layers
+
+### 1. Discover
+
+Preserve and improve the original strength of Awesome Haskell: a structured map of the ecosystem.
+
+Each area may include:
+
+- important projects;
+- relevant Hackage categories;
+- official documentation;
+- learning materials;
+- community resources;
+- related ecosystem maps.
+
+Discovery can be broad, but it must remain organized and understandable.
+
+### 2. Choose
+
+Each important category should include a small, opinionated decision guide.
+
+A recommendation should explain:
+
+- what the project is good for;
+- who it is suitable for;
+- when to consider an alternative;
+- its important trade-offs;
+- how it differs from nearby options.
+
+The goal is not to declare one universal winner. The goal is to make the decision legible.
+
+### 3. Verify
+
+Where practical, recommendations should be backed by current evidence.
+
+Useful evidence may include:
+
+- latest release or meaningful activity;
+- repository status;
+- compatibility with supported GHC versions;
+- documentation availability;
+- runnable examples;
+- CI verification;
+- primary-source production reports;
+- a visible `last reviewed` date.
+
+Automated signals must support human judgement, not replace it.
+
+## What makes this more useful than an AI answer
+
+Awesome Haskell should provide durable and inspectable evidence that a generated answer usually cannot guarantee:
+
+- recommendations reviewed by identifiable contributors;
+- change history and public discussion;
+- reproducible examples that are compiled in CI;
+- explicit dates and compatibility information;
+- recorded disagreements and trade-offs;
+- structured data reusable by humans, tools, and AI systems;
+- corrections that improve one shared public source rather than one private conversation.
+
+## Editorial principles
+
+### Keep the map, add judgement
+
+The project should not discard its broad taxonomy. It should add clearer paths through it.
+
+### Prefer explanation over praise
+
+Every highlighted project should say why it matters and where it does not fit.
+
+### Prefer evidence over popularity
+
+GitHub stars may be shown as context, but they are not a recommendation criterion.
+
+### Stable is not the same as abandoned
+
+A project with infrequent commits may be complete and reliable. Status labels must avoid simplistic activity rankings.
+
+### Be honest about uncertainty
+
+When maintainership, compatibility, or production readiness is unclear, say so.
+
+### Make maintenance visible
+
+Important claims should have a review date and, where possible, a source.
+
+### Curate highlights, index the rest
+
+A category may link to a comprehensive Hackage list while highlighting only a few projects with detailed guidance.
+
+## Proposed project statuses
+
+The exact vocabulary may change, but statuses should distinguish at least:
+
+- **Recommended** — actively recommended for a defined use case;
+- **Active** — meaningfully maintained;
+- **Stable** — mature and usable, with little need for frequent change;
+- **Experimental** — promising but not yet a default recommendation;
+- **Maintenance mode** — maintained conservatively, with limited new development;
+- **Historical** — important for context but generally not a new-project choice;
+- **Archived** — explicitly discontinued or archived upstream;
+- **Unknown** — not recently reviewed or insufficient evidence.
+
+## Proposed entry model
+
+A structured entry may eventually contain fields like:
+
+```yaml
+name: servant
+category: web-api
+summary: Type-level DSL for describing web APIs.
+status: recommended
+recommended_for:
+  - large typed APIs
+  - shared server and client contracts
+consider_alternatives_when:
+  - the service has only a few endpoints
+  - the team is new to type-level Haskell
+tradeoffs:
+  - expressive but conceptually demanding
+  - compile-time cost can grow with API complexity
+sources:
+  - https://docs.servant.dev/
+last_reviewed: YYYY-MM-DD
+example: examples/web-servant
+```
+
+The schema must remain practical. We should not collect metadata that nobody can maintain.
+
+## Initial scope
+
+The first iteration should prove the model on a small number of high-value areas rather than rewriting the entire repository.
+
+Suggested pilot areas:
+
+1. Getting started;
+2. Web APIs;
+3. Databases;
+4. Testing;
+5. Haskell in production.
+
+For each pilot area, aim to provide:
+
+- a short ecosystem overview;
+- a curated `Start here` section;
+- comparisons and trade-offs;
+- broader discovery links;
+- project status and review dates;
+- at least one runnable example where useful.
+
+## First milestone
+
+The first meaningful release of the new direction should include:
+
+- [ ] a revised README explaining the new purpose;
+- [ ] the existing taxonomy preserved as an ecosystem map;
+- [ ] three categories converted to the new format;
+- [ ] a minimal structured-data schema;
+- [ ] automated link checking;
+- [ ] detection of archived GitHub repositories;
+- [ ] at least two CI-tested starter examples;
+- [ ] contribution guidelines with evidence requirements;
+- [ ] a migration plan for the remaining categories.
+
+## Non-goals
+
+Awesome Haskell should not become:
+
+- a mirror of every Hackage package;
+- a leaderboard based on stars, downloads, or commit frequency;
+- an advertising directory accepting every submitted project;
+- a claim that one tool is universally best;
+- an automatically generated website without editorial responsibility;
+- a replacement for official project documentation;
+- an attempt to rewrite the whole ecosystem before publishing useful improvements.
+
+## Contribution standard
+
+A proposed highlighted recommendation should normally include:
+
+1. the use case it addresses;
+2. why it is being recommended;
+3. at least one important trade-off;
+4. nearby alternatives;
+5. evidence for maintenance or stability claims;
+6. a review date;
+7. disclosure when the contributor is affiliated with the project.
+
+Broad discovery links may use a lighter standard, but they must still be relevant and correctly categorized.
+
+## Measures of success
+
+The project succeeds when it helps users make better decisions, not when the list becomes longer.
+
+Possible signals:
+
+- a newcomer can find a viable starting stack without reading the entire repository;
+- a developer can compare major options in a category;
+- highlighted examples continue to build in CI;
+- stale recommendations are detected and reviewed;
+- maintainers contribute corrections and trade-offs;
+- other documentation and AI tools can cite or consume the structured data;
+- the number of unexplained links decreases even if the total coverage remains broad.
+
+## Open questions
+
+- Should the project keep the `awesome-haskell` name as the public identity or introduce a subtitle such as `Haskell Ecosystem Map`?
+- Which GHC versions should verified examples support?
+- Which metadata can be maintained reliably without creating excessive work?
+- Should structured data become the source of truth immediately or only after the pilot categories are validated?
+- How should disputed recommendations be documented?
+- Who should be invited as additional reviewers or maintainers?
+
+## Working principle
+
+**Discover broadly. Recommend carefully. Verify what we can. Be explicit about what we do not know.**

--- a/data/toolchain-management/ghcup.yaml
+++ b/data/toolchain-management/ghcup.yaml
@@ -1,0 +1,32 @@
+schema_version: 1
+name: GHCup
+kind: project
+category: toolchain-management
+url: https://www.haskell.org/ghcup/
+summary: Installer and version manager for GHC, Cabal, Haskell Language Server, and Stack.
+role: recommendation
+recommendation: recommended
+maintenance_status: active
+recommended_for:
+  - newcomers installing the standard Haskell toolchain
+  - developers switching between supported compiler versions
+consider_alternatives_when:
+  - the project standardizes on Nix or another reproducible environment manager
+  - system policy requires distribution-managed compiler packages
+tradeoffs:
+  - adds a toolchain-management layer that developers must understand
+  - the recommended compiler may intentionally lag behind the newest release
+alternatives:
+  - Nix
+  - system packages
+  - manually managed installations
+evidence:
+  - type: official-documentation
+    url: https://www.haskell.org/ghcup/
+    supports: canonical role as an installer and manager for the standard Haskell toolchain
+  - type: official-documentation
+    url: https://www.haskell.org/ghcup/guide/
+    supports: recommended and latest release channels plus tool-management behavior
+last_reviewed: 2026-08-02
+reviewers:
+  - krispo

--- a/docs/ENTRY_FORMAT.md
+++ b/docs/ENTRY_FORMAT.md
@@ -1,0 +1,245 @@
+# Entry format
+
+> Status: pilot format; expected to change after the first three reviewed categories
+
+The structured format exists to make claims inspectable and reusable. It should remain small enough for contributors to maintain by hand.
+
+## Design goals
+
+The format should:
+
+- distinguish discovery from recommendation;
+- separate maintenance status from recommendation level;
+- record important trade-offs;
+- link claims to evidence;
+- expose when a human last reviewed the entry;
+- remain readable without a custom application.
+
+The format should not attempt to mirror every field available from GitHub or Hackage.
+
+## Minimal discovery entry
+
+```yaml
+schema_version: 1
+name: Hoogle
+kind: project
+category: api-search
+url: https://hoogle.haskell.org/
+summary: Search Haskell APIs by name or approximate type signature.
+role: discovery
+last_reviewed: 2026-08-02
+```
+
+Required fields for discovery entries:
+
+- `schema_version`;
+- `name`;
+- `kind`;
+- `category`;
+- `url`;
+- `summary`;
+- `role`;
+- `last_reviewed`.
+
+## Reviewed recommendation entry
+
+```yaml
+schema_version: 1
+name: GHCup
+kind: project
+category: toolchain-management
+url: https://www.haskell.org/ghcup/
+summary: Installer and version manager for GHC, Cabal, HLS, and Stack.
+role: recommendation
+recommendation: recommended
+maintenance_status: active
+recommended_for:
+  - newcomers installing the standard Haskell toolchain
+  - developers switching between supported compiler versions
+consider_alternatives_when:
+  - the project standardizes on Nix or another reproducible environment manager
+tradeoffs:
+  - adds a toolchain-management layer that developers must understand
+alternatives:
+  - Nix
+  - system packages
+  - manually managed installations
+evidence:
+  - type: official-documentation
+    url: https://www.haskell.org/ghcup/
+    supports: canonical installation and tool-management role
+last_reviewed: 2026-08-02
+reviewers:
+  - krispo
+```
+
+## Fields
+
+### `schema_version`
+
+Integer identifying the entry format. The pilot uses `1`.
+
+### `name`
+
+Canonical human-readable name.
+
+### `kind`
+
+Working values:
+
+- `project`;
+- `package`;
+- `documentation`;
+- `course`;
+- `book`;
+- `article`;
+- `community`;
+- `index`;
+- `production-case-study`.
+
+The vocabulary should only expand when a real entry cannot be represented clearly.
+
+### `category`
+
+Stable machine-readable category identifier. Use lowercase kebab-case.
+
+Examples:
+
+```text
+toolchain-management
+web-api
+database
+property-testing
+compiler-tools
+```
+
+### `url`
+
+Canonical public URL. Prefer the official project site when it provides the primary documentation; otherwise use the canonical repository or publication page.
+
+### `summary`
+
+One neutral sentence describing what the entry is. Do not put recommendation claims in this field.
+
+### `role`
+
+Either:
+
+- `discovery` — indexed for exploration;
+- `recommendation` — reviewed as a choice for a defined use case.
+
+### `recommendation`
+
+Used only when `role` is `recommendation`.
+
+Working values:
+
+- `recommended` — a default choice for a defined use case;
+- `alternative` — a credible choice with a different set of trade-offs;
+- `experimental` — worth evaluating, but not a default;
+- `historical` — important context, generally not a new-project choice.
+
+### `maintenance_status`
+
+Working values:
+
+- `active`;
+- `stable`;
+- `experimental`;
+- `maintenance-mode`;
+- `historical`;
+- `archived`;
+- `unknown`.
+
+This field must not be assigned solely from commit frequency.
+
+### `recommended_for`
+
+Concrete situations in which the option is a good fit.
+
+Avoid broad entries such as “Haskell developers.” Prefer statements such as “small services that benefit from a minimal routing API.”
+
+### `consider_alternatives_when`
+
+Situations where another option may fit better. This field prevents recommendations from becoming promotional profiles.
+
+### `tradeoffs`
+
+Important costs, limitations, complexity, operational considerations, or compatibility concerns.
+
+At least one trade-off is required for a reviewed recommendation.
+
+### `alternatives`
+
+Names of nearby options readers should compare. These names may later become references to other structured entries.
+
+### `evidence`
+
+A list of sources supporting current claims.
+
+Each evidence item contains:
+
+- `type`;
+- `url`;
+- `supports` — a short explanation of which claim the source supports.
+
+Working evidence types:
+
+- `official-documentation`;
+- `release-notes`;
+- `repository`;
+- `compatibility`;
+- `maintainer-statement`;
+- `production-report`;
+- `ci`;
+- `other`.
+
+### `last_reviewed`
+
+ISO date in `YYYY-MM-DD` format. This records human inspection, not automated refresh time.
+
+### `reviewers`
+
+GitHub usernames of contributors who reviewed the recommendation and its evidence.
+
+### `affiliation`
+
+Optional disclosure when a contributor has a relationship with the project.
+
+Example:
+
+```yaml
+affiliation:
+  reviewer: example-user
+  relationship: project maintainer
+```
+
+## What should remain automated
+
+Automation may collect or check:
+
+- whether a URL resolves;
+- whether a GitHub repository is archived;
+- release timestamps;
+- CI results for repository examples;
+- package availability;
+- basic compiler compatibility signals.
+
+Automation must not independently decide:
+
+- whether a project is recommended;
+- whether infrequent activity means abandonment;
+- whether one framework is better than another;
+- whether a production claim is credible without reviewing its source.
+
+## Pilot policy
+
+Do not migrate the entire legacy README into YAML yet.
+
+First create structured entries only for projects discussed in the pilot guides. After three categories have been reviewed, evaluate:
+
+- which fields contributors actually use;
+- which fields create maintenance burden;
+- whether a JSON Schema validator is worthwhile;
+- whether generated Markdown improves or harms readability;
+- whether the structured data should become the source of truth.

--- a/docs/README_AUDIT.md
+++ b/docs/README_AUDIT.md
@@ -1,0 +1,316 @@
+# README Audit and Migration Plan
+
+> Status: initial audit for the `awesome-haskell-next` branch
+
+## Executive summary
+
+The existing README is not merely a random list of links. Its primary contribution is a broad taxonomy of the Haskell ecosystem: it identifies important areas, connects readers to concrete projects, and links those areas to larger Hackage and Haskell Wiki indexes. That work is especially useful to newcomers who do not yet know which concepts or categories exist.
+
+The redesign should preserve that strength. The main opportunity is to make different kinds of links legible, add decision support, and establish a maintainable way to show whether highlighted information is current.
+
+The migration strategy is therefore:
+
+> **Keep the ecosystem map, distinguish recommendations from indexes, and add evidence gradually.**
+
+## What the current README does well
+
+### 1. It provides an ecosystem taxonomy
+
+The README groups the ecosystem into recognizable areas such as compilers, concurrency, configuration, cryptography, data access, databases, web development, messaging, science, and streaming.
+
+For a newcomer, naming these areas is already useful: it turns an unfamiliar ecosystem into a navigable map.
+
+### 2. It connects several levels of discovery
+
+The list combines:
+
+- foundational tools such as GHC, Cabal, Stack, Hackage, and Hoogle;
+- individual libraries and applications;
+- Hackage category indexes;
+- Haskell Wiki overview pages;
+- tutorials, courses, videos, conferences, and community links.
+
+This combination helps readers move from a broad topic to either a concrete project or a more comprehensive source.
+
+### 3. It covers more than packages
+
+The resources section acknowledges that an ecosystem includes learning materials, communities, conferences, applications, and development practices—not only libraries.
+
+### 4. It has accumulated community knowledge
+
+The repository history and contributions represent years of discovery and classification work. The redesign should retain attribution and avoid a destructive rewrite that discards useful context.
+
+## Where the current README becomes difficult to use
+
+### 1. Different link types look equivalent
+
+A direct project recommendation, a Hackage category, a Wiki overview, an old tutorial, and a historical project all appear as similar bullet points.
+
+Readers cannot easily tell whether an item means:
+
+- start here;
+- one possible option;
+- comprehensive external index;
+- background reading;
+- historical context;
+- unreviewed legacy entry.
+
+### 2. The list offers discovery but little decision support
+
+The current structure often answers “what exists?” but not:
+
+- which option fits a particular task;
+- what the major alternatives are;
+- what trade-offs matter;
+- whether a project is suitable for newcomers or production;
+- when the information was last reviewed.
+
+### 3. Category granularity is uneven
+
+Some sections list individual projects, some mostly forward to Hackage categories, and others point to Wiki pages. Some categories are highly specific while others cover broad domains.
+
+This is not inherently wrong, but the intended role of each section is not stated.
+
+### 4. Current and historical resources are mixed
+
+The README contains entries that may be active, stable, obsolete, moved, or historical. Without status or review metadata, a newcomer has to independently investigate each item.
+
+### 5. Descriptions are inconsistent
+
+Descriptions vary in tone, detail, capitalization, punctuation, and specificity. Some explain a use case; others restate the link title or use promotional language.
+
+### 6. The table of contents exposes implementation structure, not user goals
+
+The existing contents list is useful when a reader already knows the relevant category. It is less helpful to someone asking:
+
+- How do I start?
+- How do I build an API?
+- What should I use with PostgreSQL?
+- How is Haskell used in production?
+
+Goal-oriented entry points should complement, not replace, the taxonomy.
+
+### 7. A single large Markdown file limits maintainability
+
+As the project adds comparisons, sources, review dates, and examples, one README will become increasingly difficult to review and update. Structured data and focused guides should eventually become the source material for generated summaries.
+
+## Content model: distinguish the role of each item
+
+Each existing entry should eventually be classified into one of these roles.
+
+| Role | Purpose | Review standard |
+| --- | --- | --- |
+| Highlighted choice | Helps the reader choose a tool for a defined use case | Rationale, trade-offs, alternatives, evidence, review date |
+| Ecosystem project | Broad discovery without an explicit recommendation | Correct categorization and current destination |
+| Comprehensive index | Links to Hackage or another broad catalog | Relevance and accessibility |
+| Official resource | Primary documentation or official ecosystem page | Correct destination and scope |
+| Learning resource | Tutorial, book, course, or video | Audience, level, currency, and accessibility |
+| Production case | Evidence of real-world Haskell usage | Primary source, date, scope, and current-status caveat |
+| Historical resource | Important context but not a default current choice | Clearly labeled as historical |
+
+The immediate migration does not require assigning every item at once. The model should first be tested in pilot sections.
+
+## What should be preserved
+
+- The broad category map.
+- Links to relevant Hackage categories.
+- Links to official Haskell and project documentation.
+- Useful applications written in Haskell, not only libraries.
+- Learning and community resources.
+- Repository history, contributors, and attribution.
+- The ability to browse beyond a small curated shortlist.
+
+## What should be added
+
+- Goal-oriented entry paths.
+- A concise `Start here` block in important categories.
+- Explicit trade-offs and nearby alternatives.
+- Clear separation between recommendation and discovery.
+- Project and resource statuses where useful.
+- `Last reviewed` dates for important claims.
+- Primary sources for production-readiness statements.
+- CI-tested starter examples.
+- Automated link and repository-status checks.
+- A practical structured-data schema.
+
+## What should be retired or reduced
+
+- Empty or broken links.
+- Duplicate category links that add no distinct value.
+- Unexplained promotional submissions.
+- Claims such as “best” without criteria or evidence.
+- Historical resources presented as current defaults.
+- Repeated boilerplate such as “a collaborative Hackage list” when one category index can represent the same information more clearly.
+- Metadata that cannot be maintained reliably.
+
+Retiring an item does not always mean deleting its history. Important obsolete projects may move to a clearly labeled historical section.
+
+## Proposed migration phases
+
+### Phase 0 — establish the direction
+
+- Keep the original README unchanged.
+- Add `VISION.md`.
+- Add a draft next-generation entry point.
+- Record this audit and migration plan.
+
+### Phase 1 — create one complete newcomer path
+
+Build a `Getting started` guide that includes:
+
+- a minimal installation path;
+- editor and language-server setup;
+- one small starter project;
+- an explanation of Cabal, GHCup, Hackage, Hoogle, and optional Stack usage;
+- a learning path with audience and currency notes;
+- a CI-tested example.
+
+This guide should be useful independently of the rest of the redesign.
+
+### Phase 2 — test the decision-guide format
+
+Convert three high-value categories:
+
+1. Web APIs;
+2. Databases;
+3. Testing.
+
+Each should contain:
+
+- a short overview;
+- several highlighted choices, not an exhaustive ranking;
+- use cases and trade-offs;
+- broader Hackage and documentation links;
+- statuses and review dates;
+- at least one runnable example where appropriate.
+
+### Phase 3 — introduce structured data and automation
+
+After the pilot format proves useful:
+
+- define the minimal YAML schema;
+- move pilot entries into structured files;
+- generate summary tables or README sections;
+- check links automatically;
+- detect archived GitHub repositories;
+- expose review dates and verification results.
+
+Structured data should follow the editorial model, not determine it prematurely.
+
+### Phase 4 — migrate the remaining map incrementally
+
+Review categories in manageable groups. For each category:
+
+- preserve useful discovery coverage;
+- remove duplicate or broken entries;
+- classify historical resources;
+- add a small curated layer only when contributors can defend it;
+- avoid blocking publication on complete migration.
+
+### Phase 5 — replace the public entry point
+
+Replace the root README only when the new version:
+
+- explains the project clearly;
+- contains at least one complete newcomer path;
+- demonstrates the new category format;
+- links to the preserved broad map;
+- has contribution rules suitable for the new model.
+
+## Proposed repository shape
+
+```text
+README.md                      # eventual generated or concise entry point
+VISION.md                      # mission and editorial principles
+CONTRIBUTING.md                # evidence and review requirements
+
+data/
+  projects/                    # structured project records after pilot validation
+  resources/                   # structured learning and ecosystem resources
+
+guides/
+  getting-started.md
+  choosing-a-web-api-stack.md
+  choosing-a-database-library.md
+  testing.md
+  haskell-in-production.md
+
+examples/
+  beginner-cli/
+  web-api/
+  postgres/
+
+scripts/
+  check-links
+  check-repositories
+  generate-readme
+
+docs/
+  README_AUDIT.md
+  schema.md
+  migration.md
+```
+
+This is a direction, not a requirement to create every directory immediately.
+
+## Pilot acceptance criteria
+
+A pilot guide should not be considered complete merely because it contains prose. It should allow a reader to make or validate a decision.
+
+Minimum criteria:
+
+- the audience and task are explicit;
+- highlighted options have distinct use cases;
+- at least one meaningful disadvantage is documented for each highlighted option;
+- nearby alternatives are named;
+- important status claims have sources;
+- a review date is visible;
+- broad discovery links remain available;
+- examples build in CI when an example is part of the recommendation.
+
+## Editorial risks to manage
+
+### Maintainer bias
+
+Recommendations inevitably contain judgement. The project should make the reasoning inspectable and record material disagreements rather than claiming false objectivity.
+
+### Activity-score bias
+
+Recent commits do not automatically mean quality, and infrequent commits do not automatically mean abandonment. Automated activity data must remain supporting evidence.
+
+### Scope explosion
+
+The project can become unmaintainable if every entry requires extensive bespoke research. Detailed review should focus on highlighted choices; broad discovery entries use a lighter standard.
+
+### Premature automation
+
+Generating a polished website from weak or unreviewed data would not improve the underlying guide. Editorial usefulness should precede infrastructure complexity.
+
+### Destructive cleanup
+
+Removing old links without recording why may erase useful history. Migration commits should be small and explain whether entries were moved, merged, marked historical, or removed as broken.
+
+## Recommended next implementation step
+
+Create `guides/getting-started.md` as the first complete vertical slice. It should establish:
+
+- the writing style;
+- the distinction between recommendation and exploration;
+- the evidence format;
+- the review-date convention;
+- the first runnable example requirements.
+
+Only after that guide is reviewed should the project settle the final YAML schema.
+
+## Decisions still needed
+
+- Keep `Awesome Haskell` as the sole name, or add a subtitle such as `Haskell Ecosystem Map`?
+- Should the original broad map remain in the root README, move to `ecosystem-map.md`, or be generated from data?
+- Which GHC releases should examples test?
+- How should multiple maintainers approve a `Recommended` status?
+- Should recommendation disputes be documented inline, in issues, or in decision records?
+- Which parts of project health can be automated without creating misleading scores?
+
+## Working conclusion
+
+The original README performed useful information-architecture work. The redesign should not apologize for that work or discard it. Its purpose is to make the taxonomy more actionable, transparent, and verifiable for the next generation of users.

--- a/examples/beginner-cli/README.md
+++ b/examples/beginner-cli/README.md
@@ -1,0 +1,64 @@
+# Beginner CLI example
+
+A minimal Haskell project that demonstrates a conventional Cabal layout:
+
+- reusable logic in `src/`;
+- a small executable in `app/`;
+- a test suite in `test/`;
+- no third-party dependencies, so the first build remains easy to understand.
+
+## Build
+
+From this directory:
+
+```sh
+cabal build all
+```
+
+## Run
+
+```sh
+cabal run hello-haskell
+```
+
+Expected output:
+
+```text
+Hello, Haskell!
+```
+
+Pass a name after `--`:
+
+```sh
+cabal run hello-haskell -- Ada Lovelace
+```
+
+Expected output:
+
+```text
+Hello, Ada Lovelace!
+```
+
+## Test
+
+```sh
+cabal test all --test-show-details=direct
+```
+
+## What to notice
+
+1. `AwesomeHaskell.Greeting` contains pure logic that is easy to test.
+2. `Main` performs the effectful work: reading arguments and printing output.
+3. The executable and tests depend on the local library through the Cabal package.
+4. Compiler warnings are enabled centrally through a Cabal `common` stanza.
+5. CI builds and tests this example on more than one recent GHC release.
+
+## Next steps
+
+Good small exercises:
+
+- add a `--help` option;
+- reject an empty name explicitly;
+- add punctuation as an option;
+- replace the manual argument handling with `optparse-applicative`;
+- replace the manual test helper with a testing library after understanding the basic structure.

--- a/examples/beginner-cli/app/Main.hs
+++ b/examples/beginner-cli/app/Main.hs
@@ -1,0 +1,9 @@
+module Main (main) where
+
+import AwesomeHaskell.Greeting (greeting)
+import System.Environment (getArgs)
+
+main :: IO ()
+main = do
+  arguments <- getArgs
+  putStrLn (greeting arguments)

--- a/examples/beginner-cli/awesome-haskell-beginner-cli.cabal
+++ b/examples/beginner-cli/awesome-haskell-beginner-cli.cabal
@@ -1,0 +1,44 @@
+cabal-version:      3.0
+name:               awesome-haskell-beginner-cli
+version:            0.1.0.0
+synopsis:           A minimal, tested command-line example for Haskell newcomers
+description:
+  A deliberately small example used by Awesome Haskell to demonstrate a
+  conventional Cabal project with a library, executable, and test suite.
+license:             CC0-1.0
+build-type:          Simple
+extra-source-files:  README.md
+
+common warnings
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Widentities
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+
+library
+  import:             warnings
+  exposed-modules:    AwesomeHaskell.Greeting
+  hs-source-dirs:     src
+  build-depends:      base >=4.17 && <5
+  default-language:   GHC2021
+
+executable hello-haskell
+  import:             warnings
+  main-is:            Main.hs
+  hs-source-dirs:     app
+  build-depends:
+    base >=4.17 && <5,
+    awesome-haskell-beginner-cli
+  default-language:   GHC2021
+
+test-suite beginner-cli-test
+  import:             warnings
+  type:               exitcode-stdio-1.0
+  main-is:            Spec.hs
+  hs-source-dirs:     test
+  build-depends:
+    base >=4.17 && <5,
+    awesome-haskell-beginner-cli
+  default-language:   GHC2021

--- a/examples/beginner-cli/cabal.project
+++ b/examples/beginner-cli/cabal.project
@@ -1,0 +1,3 @@
+packages: .
+
+tests: True

--- a/examples/beginner-cli/src/AwesomeHaskell/Greeting.hs
+++ b/examples/beginner-cli/src/AwesomeHaskell/Greeting.hs
@@ -1,0 +1,8 @@
+module AwesomeHaskell.Greeting
+  ( greeting
+  ) where
+
+-- | Build a friendly greeting from zero or more command-line words.
+greeting :: [String] -> String
+greeting [] = "Hello, Haskell!"
+greeting names = "Hello, " <> unwords names <> "!"

--- a/examples/beginner-cli/test/Spec.hs
+++ b/examples/beginner-cli/test/Spec.hs
@@ -1,0 +1,19 @@
+module Main (main) where
+
+import AwesomeHaskell.Greeting (greeting)
+import Control.Monad (unless)
+import System.Exit (exitFailure)
+
+main :: IO ()
+main = do
+  assertEqual "default greeting" "Hello, Haskell!" (greeting [])
+  assertEqual "named greeting" "Hello, Ada Lovelace!" (greeting ["Ada", "Lovelace"])
+  putStrLn "All beginner CLI tests passed."
+
+assertEqual :: String -> String -> String -> IO ()
+assertEqual label expected actual =
+  unless (expected == actual) $ do
+    putStrLn ("Test failed: " <> label)
+    putStrLn ("Expected: " <> show expected)
+    putStrLn ("Actual:   " <> show actual)
+    exitFailure

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -1,0 +1,289 @@
+# Getting started with Haskell
+
+> **Audience:** people installing Haskell for the first time or returning after several years  
+> **Goal:** create, edit, build, and run a small Cabal project with a working language server  
+> **Last reviewed:** 2026-08-02  
+> **Review scope:** installation path and core tools; learning-resource review is still incomplete
+
+## Recommended path
+
+For most newcomers, start with this toolchain:
+
+- **GHCup** to install and manage Haskell tools;
+- the GHCup **recommended** GHC version rather than automatically choosing the newest release;
+- **Cabal** as the first build tool to learn;
+- **Haskell Language Server (HLS)** for editor support;
+- an editor with an HLS integration, with VS Code offering the lowest-friction documented path for many beginners.
+
+This is not the only valid setup. Nix, Stack, system packages, containers, and manually managed compilers can all be appropriate. They introduce additional choices, however, and are better treated as alternative paths rather than requirements for a first program.
+
+## 1. Install the toolchain
+
+GHCup is the main installer recommended by the Haskell project. It manages GHC, Cabal, HLS, and Stack and can switch between installed versions.
+
+Follow the platform-specific instructions on the official [GHCup installation page](https://www.haskell.org/ghcup/install/).
+
+For Linux, macOS, FreeBSD, or WSL2, the documented installer command is:
+
+```sh
+curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
+```
+
+Run the installer as a normal user, not as root. Select at least:
+
+- GHC;
+- cabal-install;
+- Haskell Language Server.
+
+Installing Stack as well is reasonable because some existing projects and learning materials use it. You do not need to learn both build tools at the same time.
+
+### Why use the recommended version?
+
+GHCup distinguishes `recommended` from `latest`. Its recommended selection considers ecosystem adoption, tool compatibility, and known bugs. A newcomer generally benefits more from broad compatibility than from using a newly released compiler immediately.
+
+You can inspect and manage installed tools with:
+
+```sh
+ghcup list
+ghcup tui
+```
+
+## 2. Verify the installation
+
+Open a new terminal and run:
+
+```sh
+ghc --version
+cabal --version
+haskell-language-server-wrapper --version
+```
+
+Each command should print version information. When a command is not found, first restart the terminal and confirm that the GHCup binary directory is on `PATH`.
+
+Do not debug editor integration before these commands work in a terminal.
+
+## 3. Configure an editor
+
+### Lowest-friction starting point
+
+Install:
+
+1. [Visual Studio Code](https://code.visualstudio.com/);
+2. the [Haskell extension](https://marketplace.visualstudio.com/items?itemName=haskell.haskell).
+
+The extension communicates with HLS to provide diagnostics, hover information, navigation, formatting integrations, and other language features.
+
+The important compatibility rule is that HLS must support the GHC version used by the project. Installing both through GHCup reduces this source of mismatch.
+
+### Other editors
+
+HLS implements the Language Server Protocol, so it can also work with editors such as Neovim, Emacs, Helix, and others. Those setups are valuable, but editor-specific configuration is outside this minimal path.
+
+See the official [HLS installation documentation](https://haskell-language-server.readthedocs.io/en/stable/installation.html) when the editor cannot find the language server.
+
+## 4. Create a project
+
+Create a minimal Cabal application:
+
+```sh
+cabal init hello-haskell --non-interactive
+cd hello-haskell
+cabal run
+```
+
+Cabal creates a package description and an application entry point, resolves dependencies, builds the project, and runs the executable.
+
+The generated layout may change between Cabal versions, but a small application will usually contain files serving these roles:
+
+```text
+hello-haskell/
+├── app/
+│   └── Main.hs
+└── hello-haskell.cabal
+```
+
+Open the directory—not only `Main.hs`—in the editor so HLS can discover the project configuration.
+
+Change the program to:
+
+```haskell
+module Main where
+
+main :: IO ()
+main = putStrLn "Hello, Haskell!"
+```
+
+Then run:
+
+```sh
+cabal build
+cabal run
+```
+
+## 5. Use GHCi for small experiments
+
+For quick exploration, start the interactive environment:
+
+```sh
+ghci
+```
+
+Useful commands include:
+
+```text
+:t expression    show the type of an expression
+:i name          show information about a name
+:r               reload the current modules
+:q               exit
+```
+
+Inside a Cabal project, prefer:
+
+```sh
+cabal repl
+```
+
+This starts GHCi with the project's modules and dependencies available.
+
+## 6. Understand the core tools
+
+### GHC
+
+The compiler and interactive runtime. You will occasionally call `ghc` or `ghci` directly, but project builds are normally managed through Cabal or Stack.
+
+### Cabal
+
+Two related things share this name:
+
+- the Cabal package format and library;
+- `cabal-install`, whose command is `cabal`.
+
+Cabal describes packages, resolves dependencies, builds components, runs programs, starts REPL sessions, and executes tests.
+
+The official [Cabal getting-started guide](https://cabal.readthedocs.io/en/stable/getting-started.html) is the primary reference for the workflow used here.
+
+### Hackage
+
+The central Haskell package archive. Use it to find package versions, dependency bounds, module documentation, and source distributions.
+
+- [Hackage](https://hackage.haskell.org/)
+
+### Hoogle
+
+A search engine for Haskell APIs. It can search by function name or approximate type signature.
+
+- [Hoogle](https://hoogle.haskell.org/)
+
+For example, searching for a type such as:
+
+```haskell
+(a -> b) -> [a] -> [b]
+```
+
+can help discover `map` and related functions.
+
+### Stack
+
+An alternative project and build tool used by many existing repositories and tutorials. Install it when you need to work with a Stack project or when a chosen learning resource uses it.
+
+For a first project, learning Cabal alone keeps the number of new concepts smaller.
+
+## Cabal or Stack?
+
+Use this practical rule:
+
+- **Starting a new learning project:** begin with Cabal.
+- **Joining an existing repository:** use the tool selected by that repository.
+- **Following a course or book:** use the tool assumed by the material unless you are comfortable translating the setup.
+- **Needing both installed:** let GHCup manage both.
+
+This guide does not claim that Cabal is universally better. It chooses one default to reduce beginner decision fatigue.
+
+## What to learn next
+
+A productive early sequence is:
+
+1. expressions, functions, and types;
+2. algebraic data types and pattern matching;
+3. lists, `Maybe`, and `Either`;
+4. modules and package dependencies;
+5. basic `IO`;
+6. tests, including property-based tests;
+7. one small complete application.
+
+Do not treat advanced topics as entry requirements. Type families, effect-system comparisons, lenses, free monads, category-theory terminology, and elaborate abstraction libraries can be valuable later, but they are not necessary to write useful Haskell programs.
+
+## Explore further
+
+### Official starting material
+
+- [Haskell.org: Get Started](https://www.haskell.org/get-started/) — official setup and first-program path.
+- [GHCup first steps](https://www.haskell.org/ghcup/steps/) — GHC, GHCi, and a small Cabal project.
+- [Cabal getting started](https://cabal.readthedocs.io/en/stable/getting-started.html) — project creation and dependency management.
+- [HLS documentation](https://haskell-language-server.readthedocs.io/en/stable/) — editor tooling and troubleshooting.
+
+### Broader learning resources
+
+The project will review courses, books, exercises, and videos separately. Until that review is complete, inclusion in the legacy ecosystem map should be interpreted as discovery, not as a current recommendation.
+
+See the existing [Tutorials](../README.md#tutorials), [Video Tutorials](../README.md#video-tutorials), and [Courses](../README.md#courses) sections for broader exploration.
+
+## Common problems
+
+### The editor reports a cradle or GHC-version error
+
+First confirm that the project builds in a terminal:
+
+```sh
+cabal build
+```
+
+Then check which compiler the project uses and whether GHCup has a compatible HLS installation. Consult the HLS installation documentation rather than repeatedly reinstalling editor extensions.
+
+### Cabal cannot build a dependency
+
+Read the complete solver error. Common causes include:
+
+- unsupported GHC or dependency versions;
+- missing system libraries;
+- stale package metadata;
+- dependency bounds that do not overlap.
+
+Start with:
+
+```sh
+cabal update
+cabal build
+```
+
+Do not immediately add `--allow-newer` or edit version bounds without understanding which constraint is failing.
+
+### A tutorial uses old commands
+
+Haskell learning material can remain conceptually useful while its setup instructions age. Prefer current installation and project commands from official documentation, then adapt the tutorial's code.
+
+### HLS works for one project but not another
+
+Different projects may use different GHC versions or build configurations. HLS compatibility is project-specific; a globally installed editor extension does not remove that requirement.
+
+## Recommendation record
+
+| Decision | Recommendation | Important trade-off |
+| --- | --- | --- |
+| Toolchain manager | GHCup | Another layer to learn, but it reduces manual version management |
+| Initial compiler selection | GHCup `recommended` | May not be the newest GHC release |
+| First build tool | Cabal | Existing Stack projects still require Stack conventions |
+| Beginner editor path | VS Code + Haskell extension | Not a claim that VS Code is the best editor for every user |
+| Interactive exploration | `cabal repl` inside projects | Slightly slower startup than invoking bare `ghci` |
+
+## Evidence used for this review
+
+- [Haskell.org Get Started](https://www.haskell.org/get-started/)
+- [GHCup installation documentation](https://www.haskell.org/ghcup/install/)
+- [GHCup user guide](https://www.haskell.org/ghcup/guide/)
+- [Cabal getting-started documentation](https://cabal.readthedocs.io/en/stable/getting-started.html)
+- [Haskell Language Server installation documentation](https://haskell-language-server.readthedocs.io/en/stable/installation.html)
+
+## Review notes
+
+This guide deliberately avoids hard-coding a GHC version. GHCup's recommended version can change as compiler releases and ecosystem compatibility evolve. The guide should be reviewed when the official installation path, Cabal project workflow, or HLS distribution model changes.


### PR DESCRIPTION
## Summary

This PR establishes the foundation for an incremental redesign of Awesome Haskell while preserving the existing ecosystem map and current public README.

The direction is:

> Discover broadly. Recommend carefully. Verify what we can. Be explicit about what we do not know.

## Why

The existing repository provides useful taxonomy and discovery, especially for newcomers, but the current single-list format does not clearly distinguish:

- curated recommendations from broad indexes;
- active projects from historical references;
- verified guidance from unreviewed discovery links;
- concrete choices and trade-offs from simple existence.

The redesign keeps the original map and adds task-oriented routes, decision guidance, visible review dates, structured records, and reproducible examples.

## Included

- `VISION.md` with the proposed mission and editorial principles;
- `docs/README_AUDIT.md` with an audit and migration plan;
- `README.next.md` as a staged future entry point;
- `guides/getting-started.md` as the first reviewed vertical slice;
- `examples/beginner-cli` as the first runnable example;
- GitHub Actions verification on GHC 9.12 and 9.14;
- `CONTRIBUTING.next.md` with evidence and disclosure requirements;
- `docs/ENTRY_FORMAT.md` with the pilot structured-data model;
- `data/toolchain-management/ghcup.yaml` as the first structured recommendation.

## Verification

The beginner CLI contains a library, executable, and test suite with no third-party dependencies. The GitHub Actions matrix has passed setup, build, tests, and execution on both GHC 9.12 and GHC 9.14.

## Design constraints

- Preserve the existing taxonomy.
- Do not treat every indexed project as a recommendation.
- Do not use stars or commit frequency as automatic quality rankings.
- Keep automated metadata subordinate to human judgement.
- Add examples only when they clarify a meaningful choice or setup problem.
- Keep the current `README.md` as the public entry point until several pilot guides are complete.

## Foundation checklist

- [x] Define the vision
- [x] Audit the existing README
- [x] Create a task-oriented newcomer guide
- [x] Add the first runnable example
- [x] Add and run example CI on two GHC release lines
- [x] Add contribution guidelines for reviewed recommendations
- [x] Define and exercise a minimal structured-data format
- [x] Prepare staged documents and workflow for inclusion in `master`

## Follow-up PRs

The foundation is intentionally separated from later content work. Planned follow-up PRs will cover:

1. testing tools and practices;
2. web API choices and a runnable example;
3. database approaches and a runnable example;
4. production case studies;
5. final activation of the new README after the pilot model is proven.

This PR does not activate the redesigned README or replace the existing ecosystem map.