### PR TITLE
Add the testing decision guide and property-tested example

### DIFF
--- a/README.next.md
+++ b/README.next.md
@@ -21,7 +21,7 @@ The guide lets readers enter through a task rather than requiring them to unders
 - **[I am new to Haskell](guides/getting-started.md)** — installation, first project, editor setup, core tools, troubleshooting, and a recommended starter path. **Reviewed 2026-08-02.**
 - **I want to build a web API** — major approaches, trade-offs, database options, deployment concerns, and runnable examples. _Planned._
 - **I need to work with a database** — SQL-first and abstraction-first choices, migrations, pooling, and testing. _Planned._
-- **I want to test Haskell code** — unit, property, integration, and golden testing tools. _Planned._
+- **[I want to test Haskell code](guides/testing.md)** — choosing a runner, example assertions, property testing, golden tests, and integration-test boundaries. **Reviewed 2026-08-02.**
 - **I am evaluating Haskell for production** — real use cases, strengths, operational costs, hiring considerations, and primary sources. _Planned._
 - **[I want to explore the ecosystem](README.md)** — the broad categorized map of projects, packages, resources, and Hackage indexes.
 
@@ -37,7 +37,9 @@ A deliberately small Cabal project demonstrating:
 
 - a reusable pure library module;
 - a separate executable entry point;
-- a test suite without hidden framework machinery;
+- Tasty suite organization;
+- focused assertions with tasty-hunit;
+- a generated property with tasty-quickcheck;
 - compiler warnings enabled centrally;
 - command-line arguments;
 - automated builds and tests on GHC 9.12 and 9.14.
@@ -90,7 +92,14 @@ The pilot format is documented in [`docs/ENTRY_FORMAT.md`](docs/ENTRY_FORMAT.md)
 - human review dates from automated metadata;
 - advantages from explicit trade-offs.
 
-The first structured recommendation is [`data/toolchain-management/ghcup.yaml`](data/toolchain-management/ghcup.yaml), derived from the reviewed newcomer guide. The repository will not migrate the full legacy list into YAML until several pilot categories prove that the format is maintainable.
+Current pilot records include:
+
+- [`data/toolchain-management/ghcup.yaml`](data/toolchain-management/ghcup.yaml);
+- [`data/testing/tasty.yaml`](data/testing/tasty.yaml);
+- [`data/testing/quickcheck.yaml`](data/testing/quickcheck.yaml);
+- [`data/testing/hedgehog.yaml`](data/testing/hedgehog.yaml).
+
+The repository will not migrate the full legacy list into YAML until several pilot categories prove that the format is maintainable.
 
 ## Evidence, not rankings
 
@@ -137,12 +146,12 @@ The goal is not to compete on the amount of generated prose. The goal is to beco
 
 ## Pilot areas
 
-The new model will first be tested on a small set of high-value sections:
+The new model is being tested on a small set of high-value sections:
 
-1. **[Getting started](guides/getting-started.md)** — first reviewed guide with a [CI-tested CLI example](examples/beginner-cli);
+1. **[Getting started](guides/getting-started.md)** — reviewed guide with a [CI-tested CLI example](examples/beginner-cli);
 2. Web APIs;
 3. Databases;
-4. Testing;
+4. **[Testing](guides/testing.md)** — reviewed decision guide with example-based and property-based tests in CI;
 5. Haskell in production.
 
 A pilot section is complete only when it contains both a useful decision guide and broader discovery links. Runnable examples will be added where they materially reduce uncertainty.
@@ -174,9 +183,10 @@ During the transition:
 - [`CONTRIBUTING.next.md`](CONTRIBUTING.next.md) defines contribution and evidence standards;
 - [`docs/README_AUDIT.md`](docs/README_AUDIT.md) records what should be preserved, improved, or retired;
 - [`docs/ENTRY_FORMAT.md`](docs/ENTRY_FORMAT.md) documents the pilot structured-data format;
-- [`data/toolchain-management/ghcup.yaml`](data/toolchain-management/ghcup.yaml) is the first structured recommendation;
-- [`guides/getting-started.md`](guides/getting-started.md) demonstrates the first reviewed task-oriented guide;
-- [`examples/beginner-cli`](examples/beginner-cli) demonstrates the first runnable, tested example;
+- [`data/`](data) contains reviewed machine-readable recommendations;
+- [`guides/getting-started.md`](guides/getting-started.md) provides the newcomer path;
+- [`guides/testing.md`](guides/testing.md) provides the testing decision guide;
+- [`examples/beginner-cli`](examples/beginner-cli) demonstrates a runnable application and mixed test suite;
 - [`.github/workflows/verify-examples.yml`](.github/workflows/verify-examples.yml) verifies examples across supported compilers.
 
 The original README will only be replaced after the new entry point is useful on its own. History and attribution will be preserved.

--- a/README.next.md
+++ b/README.next.md
@@ -96,6 +96,7 @@ Current pilot records include:
 
 - [`data/toolchain-management/ghcup.yaml`](data/toolchain-management/ghcup.yaml);
 - [`data/testing/tasty.yaml`](data/testing/tasty.yaml);
+- [`data/testing/hspec.yaml`](data/testing/hspec.yaml);
 - [`data/testing/quickcheck.yaml`](data/testing/quickcheck.yaml);
 - [`data/testing/hedgehog.yaml`](data/testing/hedgehog.yaml).
 

--- a/data/testing/hedgehog.yaml
+++ b/data/testing/hedgehog.yaml
@@ -1,0 +1,35 @@
+schema_version: 1
+name: Hedgehog
+kind: package
+category: property-testing
+url: https://hackage.haskell.org/package/hedgehog
+summary: Property-based testing library with integrated shrinking and explicit generator composition.
+role: recommendation
+recommendation: alternative
+maintenance_status: active
+recommended_for:
+  - projects where generated values must preserve complex invariants while shrinking
+  - teams that prefer explicit generators over widespread Arbitrary instances
+  - systems using state-machine property testing
+consider_alternatives_when:
+  - the project depends heavily on existing QuickCheck instances and integrations
+  - contributors are already productive with QuickCheck and have no shrinking problem to solve
+  - minimizing property-testing dependencies and concepts is more important than integrated shrinking
+tradeoffs:
+  - smaller ecosystem and fewer ready-made integrations than QuickCheck
+  - explicit generator design can require more initial work
+  - adopting it alongside QuickCheck may create two overlapping testing styles
+alternatives:
+  - QuickCheck
+  - SmallCheck
+  - LeanCheck
+evidence:
+  - type: official-documentation
+    url: https://hackage.haskell.org/package/hedgehog
+    supports: integrated shrinking, monadic generators, range combinators, diffs, and state-machine testing
+  - type: compatibility
+    url: https://hackage.haskell.org/package/tasty-hedgehog
+    supports: integration with Tasty and compatibility with current Hedgehog and Tasty release ranges
+last_reviewed: 2026-08-02
+reviewers:
+  - krispo

--- a/data/testing/hspec.yaml
+++ b/data/testing/hspec.yaml
@@ -1,0 +1,35 @@
+schema_version: 1
+name: Hspec
+kind: package
+category: testing
+url: https://hspec.github.io/
+summary: Behavior-oriented Haskell testing framework with expectations, hooks, discovery, and property-test integration.
+role: recommendation
+recommendation: alternative
+maintenance_status: active
+recommended_for:
+  - teams that prefer nested behavior descriptions and expectation syntax
+  - projects with an established Hspec suite and conventions
+  - tests that benefit from Hspec hooks and automatic spec discovery
+consider_alternatives_when:
+  - one runner must combine a wide variety of provider-based test styles explicitly
+  - nested prose would obscure simple function-level behavior
+  - the team prefers explicit test-tree composition
+tradeoffs:
+  - deeply nested descriptions can hide setup and concrete values
+  - automatic discovery introduces naming and build-tool conventions
+  - mixed testing styles may require integration packages
+alternatives:
+  - Tasty
+  - HUnit
+  - sydtest
+evidence:
+  - type: official-documentation
+    url: https://hspec.github.io/
+    supports: expectations, hooks, discovery, filtering, parallel execution, and QuickCheck integration
+  - type: official-documentation
+    url: https://hspec.github.io/quickcheck.html
+    supports: direct property-testing integration with QuickCheck
+last_reviewed: 2026-08-02
+reviewers:
+  - krispo

--- a/data/testing/quickcheck.yaml
+++ b/data/testing/quickcheck.yaml
@@ -1,0 +1,38 @@
+schema_version: 1
+name: QuickCheck
+kind: package
+category: property-testing
+url: https://hackage.haskell.org/package/QuickCheck
+summary: Property-based testing library using generated inputs and shrinking to find small counterexamples.
+role: recommendation
+recommendation: recommended
+maintenance_status: active
+recommended_for:
+  - teams adopting property-based testing for the first time in Haskell
+  - projects benefiting from the broad QuickCheck ecosystem and existing Arbitrary instances
+  - suites integrated with Tasty or Hspec
+consider_alternatives_when:
+  - generator invariants make integrated shrinking a decisive requirement
+  - state-machine testing is central and Hedgehog's model is preferred
+  - implicit Arbitrary instances obscure the domain distribution
+tradeoffs:
+  - default generators may produce valid but irrelevant data
+  - custom shrinkers can violate invariants or produce poor counterexamples
+  - passing properties can provide false confidence when input distributions are not inspected
+alternatives:
+  - Hedgehog
+  - SmallCheck
+  - LeanCheck
+evidence:
+  - type: official-documentation
+    url: https://hackage.haskell.org/package/QuickCheck
+    supports: generated property testing, shrinking, data classification, and custom generators
+  - type: release-notes
+    url: https://hackage.haskell.org/package/QuickCheck-2.18.0.0/changelog
+    supports: continued releases and maintenance as of 2026
+  - type: ci
+    url: https://github.com/krispo/awesome-haskell/actions
+    supports: repository example runs a QuickCheck property through Tasty on GHC 9.12 and 9.14
+last_reviewed: 2026-08-02
+reviewers:
+  - krispo

--- a/data/testing/tasty.yaml
+++ b/data/testing/tasty.yaml
@@ -1,0 +1,34 @@
+schema_version: 1
+name: Tasty
+kind: package
+category: testing
+url: https://hackage.haskell.org/package/tasty
+summary: Extensible test runner that combines multiple testing styles in one test tree.
+role: recommendation
+recommendation: recommended
+maintenance_status: active
+recommended_for:
+  - new libraries and applications that need a general-purpose test runner
+  - projects combining unit, property, golden, or integration tests
+  - teams that value explicit suite composition and command-line filtering
+consider_alternatives_when:
+  - the team strongly prefers Hspec's nested behavior-specification style
+  - the project has a tiny suite and does not need provider packages or runner features
+tradeoffs:
+  - assertions and test styles are supplied by separate provider packages
+  - explicit TestTree construction can feel verbose in large suites
+  - automatic test discovery requires additional tooling and conventions
+alternatives:
+  - Hspec
+  - HUnit
+  - custom Cabal test runner
+evidence:
+  - type: official-documentation
+    url: https://hackage.haskell.org/package/tasty
+    supports: provider architecture, test-tree model, filtering, parallel execution, and resource management
+  - type: ci
+    url: https://github.com/krispo/awesome-haskell/actions
+    supports: repository example builds and runs a Tasty suite on GHC 9.12 and 9.14
+last_reviewed: 2026-08-02
+reviewers:
+  - krispo

--- a/examples/beginner-cli/README.md
+++ b/examples/beginner-cli/README.md
@@ -1,11 +1,12 @@
 # Beginner CLI example
 
-A minimal Haskell project that demonstrates a conventional Cabal layout:
+A small Haskell project demonstrating a conventional Cabal layout and a realistic starter test stack:
 
 - reusable logic in `src/`;
 - a small executable in `app/`;
-- a test suite in `test/`;
-- no third-party dependencies, so the first build remains easy to understand.
+- a Tasty test suite in `test/`;
+- focused example assertions with `tasty-hunit`;
+- one generated property with `tasty-quickcheck`.
 
 ## Build
 
@@ -45,20 +46,38 @@ Hello, Ada Lovelace!
 cabal test all --test-show-details=direct
 ```
 
+The test suite contains two complementary forms of evidence:
+
+1. concrete examples that document expected behavior;
+2. a property that generates non-empty alphabetic name words and checks that every generated word is preserved in the rendered greeting.
+
 ## What to notice
 
 1. `AwesomeHaskell.Greeting` contains pure logic that is easy to test.
 2. `Main` performs the effectful work: reading arguments and printing output.
-3. The executable and tests depend on the local library through the Cabal package.
-4. Compiler warnings are enabled centrally through a Cabal `common` stanza.
-5. CI builds and tests this example on more than one recent GHC release.
+3. Tasty organizes example-based and property-based tests in one tree.
+4. The property uses an explicit generator instead of arbitrary strings containing irrelevant control characters.
+5. The executable and tests depend on the local library through the Cabal package.
+6. Compiler warnings are enabled centrally through a Cabal `common` stanza.
+7. CI builds and tests this example on GHC 9.12 and 9.14.
+
+## Why these dependencies?
+
+- `tasty` provides suite organization, filtering, and reporting;
+- `tasty-hunit` provides direct example assertions;
+- `tasty-quickcheck` integrates QuickCheck properties into the same runner.
+
+The example deliberately does not add automatic test discovery or a large application framework. The goal is to make each layer visible.
 
 ## Next steps
 
 Good small exercises:
 
-- add a `--help` option;
+- add a `--help` option and test it at the process boundary;
 - reject an empty name explicitly;
-- add punctuation as an option;
-- replace the manual argument handling with `optparse-applicative`;
-- replace the manual test helper with a testing library after understanding the basic structure.
+- inspect QuickCheck output after intentionally breaking `greeting`;
+- classify generated names by length;
+- add punctuation as an option and define a property for it;
+- replace the QuickCheck property with Hedgehog to compare generator and shrinking styles.
+
+See [`../../guides/testing.md`](../../guides/testing.md) for the broader testing decision guide.

--- a/examples/beginner-cli/awesome-haskell-beginner-cli.cabal
+++ b/examples/beginner-cli/awesome-haskell-beginner-cli.cabal
@@ -40,5 +40,8 @@ test-suite beginner-cli-test
   hs-source-dirs:     test
   build-depends:
     base >=4.17 && <5,
-    awesome-haskell-beginner-cli
+    awesome-haskell-beginner-cli,
+    tasty >=1.5 && <1.6,
+    tasty-hunit >=0.10 && <0.11,
+    tasty-quickcheck >=0.11 && <0.12
   default-language:   GHC2021

--- a/examples/beginner-cli/test/Spec.hs
+++ b/examples/beginner-cli/test/Spec.hs
@@ -1,19 +1,56 @@
 module Main (main) where
 
 import AwesomeHaskell.Greeting (greeting)
-import Control.Monad (unless)
-import System.Exit (exitFailure)
+import Data.List (isInfixOf)
+import Test.Tasty (TestTree, defaultMain, testGroup)
+import Test.Tasty.HUnit (testCase, (@?=))
+import Test.Tasty.QuickCheck
+  ( Gen
+  , Property
+  , counterexample
+  , elements
+  , forAll
+  , listOf1
+  , testProperty
+  )
 
 main :: IO ()
-main = do
-  assertEqual "default greeting" "Hello, Haskell!" (greeting [])
-  assertEqual "named greeting" "Hello, Ada Lovelace!" (greeting ["Ada", "Lovelace"])
-  putStrLn "All beginner CLI tests passed."
+main = defaultMain tests
 
-assertEqual :: String -> String -> String -> IO ()
-assertEqual label expected actual =
-  unless (expected == actual) $ do
-    putStrLn ("Test failed: " <> label)
-    putStrLn ("Expected: " <> show expected)
-    putStrLn ("Actual:   " <> show actual)
-    exitFailure
+tests :: TestTree
+tests =
+  testGroup
+    "beginner CLI"
+    [ exampleTests
+    , propertyTests
+    ]
+
+exampleTests :: TestTree
+exampleTests =
+  testGroup
+    "examples"
+    [ testCase "uses a default subject" $
+        greeting [] @?= "Hello, Haskell!"
+    , testCase "joins command-line words" $
+        greeting ["Ada", "Lovelace"] @?= "Hello, Ada Lovelace!"
+    ]
+
+propertyTests :: TestTree
+propertyTests =
+  testGroup
+    "properties"
+    [ testProperty "preserves every generated name word" prop_preservesNameWords
+    ]
+
+prop_preservesNameWords :: Property
+prop_preservesNameWords =
+  forAll nameWords $ \names ->
+    let result = greeting names
+     in counterexample ("Generated greeting: " <> show result) $
+          all (`isInfixOf` result) names
+
+nameWords :: Gen [String]
+nameWords = listOf1 (listOf1 (elements alphabet))
+
+alphabet :: [Char]
+alphabet = ['a' .. 'z'] <> ['A' .. 'Z']

--- a/guides/testing.md
+++ b/guides/testing.md
@@ -1,0 +1,340 @@
+# Testing Haskell code
+
+> **Audience:** Haskell developers choosing a test stack for a library or application  
+> **Goal:** choose a practical combination of example-based, property-based, golden, and integration tests  
+> **Last reviewed:** 2026-08-02  
+> **Review scope:** core test runners and property-testing libraries; specialized domain packages are discovery-only unless stated otherwise
+
+## Recommended starting stack
+
+For a new general-purpose project, start with:
+
+- **Tasty** as the test runner and suite organizer;
+- **tasty-hunit** for focused example-based assertions;
+- **tasty-quickcheck** for property-based tests;
+- plain Cabal test suites executed with `cabal test`;
+- explicit integration or golden tests only when they protect behavior that unit and property tests cannot express clearly.
+
+This is a default path, not a claim that every project should use the same framework.
+
+Choose **Hspec** instead when the team strongly prefers nested, behavior-oriented specifications and its expectation syntax. Choose **Hedgehog** instead of QuickCheck when integrated shrinking, explicit generator composition, or state-machine testing is central to the project.
+
+## Start with the kind of confidence you need
+
+A testing tool is only useful in relation to the failure it is meant to catch.
+
+| Need | Useful test type | Typical tools |
+| --- | --- | --- |
+| One input should produce one expected result | Example-based unit test | tasty-hunit, HUnit, Hspec |
+| A rule should hold across many generated inputs | Property test | QuickCheck, Hedgehog |
+| Rendered text or serialized output must remain stable | Golden test | tasty-golden |
+| Several modules or an external service must work together | Integration test | Tasty/Hspec plus resource setup |
+| A command-line program must start and return correctly | Process-level test | tasty-program or a custom process test |
+| Stateful commands must preserve invariants | State-machine property test | Hedgehog, QuickCheck state-machine libraries |
+
+Do not replace clear example tests with generated tests merely because property testing is fashionable. Do not write hundreds of narrow examples when one well-chosen property captures the real rule.
+
+## Tasty: a composable test runner
+
+Tasty organizes tests into a `TestTree` and delegates actual assertions to provider packages. Its ecosystem includes providers for HUnit, QuickCheck, Hedgehog, golden tests, external programs, and other styles.
+
+Use Tasty when:
+
+- a project needs more than one kind of test;
+- command-line filtering and deterministic reporting are valuable;
+- tests need shared resource acquisition and cleanup;
+- the team prefers explicit suite composition;
+- the project may grow from simple unit tests into a mixed suite.
+
+Important trade-offs:
+
+- Tasty itself does not provide most assertion styles; provider packages are separate dependencies;
+- explicit `TestTree` construction can feel verbose;
+- automatic discovery is available through additional packages, but explicit lists are easier to understand in small projects;
+- choosing Tasty does not choose between QuickCheck and Hedgehog.
+
+A small suite looks like:
+
+```haskell
+module Main (main) where
+
+import Test.Tasty (defaultMain, testGroup)
+import Test.Tasty.HUnit (testCase, (@?=))
+import Test.Tasty.QuickCheck (testProperty)
+
+main :: IO ()
+main =
+  defaultMain $
+    testGroup
+      "tests"
+      [ testCase "example" (reverse [1, 2, 3] @?= [3, 2, 1])
+      , testProperty "reverse twice" $ \xs -> reverse (reverse xs :: [Int]) == xs
+      ]
+```
+
+## Hspec: a spec-oriented runner
+
+Hspec provides nested descriptions and expectation-focused syntax. It supports parallel execution, automatic spec discovery, QuickCheck integration, and interoperability with HUnit.
+
+Use Hspec when:
+
+- readable behavior descriptions are a strong team preference;
+- tests are naturally discussed as contexts and expected outcomes;
+- automatic discovery fits the repository's conventions;
+- the team already has an established Hspec suite.
+
+Important trade-offs:
+
+- deeply nested prose can hide the actual setup and values involved;
+- spec descriptions can become redundant when function names and types already communicate the behavior;
+- mixing many testing styles may require integration packages or conventions;
+- migrating between Hspec and Tasty is possible, but the suite structure is different.
+
+A small suite looks like:
+
+```haskell
+module Main (main) where
+
+import Test.Hspec
+
+main :: IO ()
+main = hspec $ do
+  describe "reverse" $ do
+    it "reverses a concrete list" $
+      reverse [1, 2, 3 :: Int] `shouldBe` [3, 2, 1]
+
+    it "is its own inverse" $
+      property $ \xs -> reverse (reverse xs :: [Int]) == xs
+```
+
+Neither Tasty nor Hspec makes tests better automatically. Prefer the runner whose suite structure the team can maintain consistently.
+
+## HUnit: assertions and small unit suites
+
+HUnit is a direct unit-testing framework inspired by JUnit. It provides assertions, named test cases, grouping, and a text runner.
+
+Use HUnit directly when:
+
+- the test suite is very small;
+- another framework exposes HUnit-style assertions;
+- a library wants minimal, familiar assertion primitives.
+
+For a growing mixed suite, use HUnit through **tasty-hunit** or Hspec interoperability rather than building a custom runner around `runTestTT`.
+
+HUnit's infrequent release history should not by itself be interpreted as abandonment: the API is small and mature. Review compatibility and maintainer evidence rather than using commit frequency as the only signal.
+
+## QuickCheck: established property-based testing
+
+QuickCheck tests properties against many randomly generated values. It supports custom generators, shrinking, classification and coverage of generated data, function generation, and monadic properties.
+
+Use QuickCheck when:
+
+- the project wants the most established Haskell property-testing ecosystem;
+- existing types already have useful `Arbitrary` instances;
+- integration with Tasty or Hspec is desired;
+- the team wants a gradual path from simple Boolean properties to custom generators and shrinkers.
+
+Important trade-offs:
+
+- default `Arbitrary` instances may generate values that are technically valid but irrelevant to the domain;
+- custom shrinking can be subtle, and a bad shrinker may violate generator invariants;
+- a property that passes on poorly distributed data can create false confidence;
+- random generation does not replace explicit boundary examples.
+
+A useful property should state a domain rule, not merely restate the implementation.
+
+Weak:
+
+```haskell
+prop_greeting words = greeting words == "Hello, " <> unwords words <> "!"
+```
+
+This mostly copies the implementation.
+
+Stronger:
+
+```haskell
+prop_greeting_preserves_words words =
+  all (`isInfixOf` greeting words) words
+```
+
+Even then, constrain the generator so the property describes meaningful names rather than arbitrary control characters and empty strings.
+
+## Hedgehog: integrated generation and shrinking
+
+Hedgehog integrates shrinking into generators so reduced counterexamples continue to respect generator structure. It also provides monadic generators, range combinators, useful diffs, concurrent property execution, and state-machine testing support.
+
+Use Hedgehog when:
+
+- generator invariants are complex and shrinking quality matters greatly;
+- state-machine testing is a first-class requirement;
+- the team prefers explicit generators over widespread `Arbitrary` instances;
+- monadic generator composition makes the domain model clearer.
+
+Important trade-offs:
+
+- its ecosystem and number of ready-made instances are smaller than QuickCheck's;
+- teams familiar with QuickCheck must learn a different generator style;
+- integration with a common runner may require `tasty-hedgehog` or `hspec-hedgehog`;
+- explicit generator design is valuable but can add up-front work.
+
+## QuickCheck or Hedgehog?
+
+| Question | QuickCheck | Hedgehog |
+| --- | --- | --- |
+| Existing ecosystem and integrations | Strongest | Good but smaller |
+| Ready-made typeclass instances | Broad | More explicit generator style |
+| Shrinking model | Separate `shrink` logic | Integrated with generators |
+| Beginner familiarity in Haskell material | More common | Less common |
+| Stateful model testing | Available through libraries | A prominent built-in use case |
+| Best default for this guide | Yes | Alternative for specific needs |
+
+Do not run both in the same project without a concrete reason. The conceptual overlap creates maintenance cost, and most teams benefit from one primary property-testing style.
+
+## Golden tests
+
+Golden tests compare current output with an approved reference file. They are useful for:
+
+- pretty printers;
+- generated source code;
+- command-line output;
+- serialization fixtures;
+- compiler diagnostics;
+- document conversion.
+
+`tasty-golden` integrates this style with Tasty and provides an `--accept` workflow for updating expected outputs.
+
+Important rules:
+
+- review golden-file changes as code changes;
+- never run automatic acceptance in CI;
+- keep outputs deterministic;
+- normalize platform-specific paths, timestamps, encodings, and line endings;
+- prefer semantic assertions when a large snapshot obscures the actual requirement.
+
+Golden tests are regression detectors. They do not prove that the approved output is correct.
+
+## Integration tests
+
+Integration tests should exercise a meaningful boundary:
+
+- a real database schema and queries;
+- a network protocol implementation;
+- filesystem behavior;
+- an executable process;
+- interaction between independently configured components.
+
+Keep these tests separate from fast pure tests when they require expensive setup or external services. A practical structure is:
+
+```text
+test/
+  unit/
+  property/
+  integration/
+  golden/
+```
+
+The exact directories matter less than being able to run focused subsets locally and in CI.
+
+With Tasty, resource acquisition can be shared across groups. With Hspec, use hooks such as `beforeAll`, `around`, or explicit bracketed setup. Regardless of runner:
+
+- isolate test data;
+- clean up resources even after failure;
+- avoid depending on test execution order;
+- make timeouts explicit;
+- report enough context to reproduce a failure.
+
+## What to test in pure Haskell code
+
+Pure functions make testing easier, but not every pure function deserves a test.
+
+Prioritize:
+
+- business rules and invariants;
+- parsers and renderers;
+- round trips such as `decode . encode`;
+- normalization and idempotence;
+- boundary conditions;
+- transformations where information must not be lost;
+- bug regressions.
+
+Avoid tests that only verify language behavior or restate a trivial definition.
+
+## A practical progression
+
+For a new project:
+
+1. add one Cabal test suite;
+2. choose Tasty or Hspec as the primary runner;
+3. write a few concrete examples for core behavior;
+4. identify one real invariant and express it with QuickCheck or Hedgehog;
+5. inspect generated-data distribution and counterexamples;
+6. add integration tests at actual system boundaries;
+7. add golden tests only for stable, reviewable output;
+8. keep all test commands reproducible in CI.
+
+## Runnable example
+
+The repository's [`examples/beginner-cli`](../examples/beginner-cli) demonstrates the recommended starter combination:
+
+- Tasty for suite organization;
+- tasty-hunit for concrete examples;
+- tasty-quickcheck for a property;
+- CI execution on GHC 9.12 and 9.14.
+
+Run it with:
+
+```sh
+cd examples/beginner-cli
+cabal test all --test-show-details=direct
+```
+
+## Decision record
+
+| Decision | Default recommendation | Consider an alternative when |
+| --- | --- | --- |
+| General test runner | Tasty | The team strongly prefers Hspec's spec syntax |
+| Example assertions | tasty-hunit | Existing Hspec conventions are established |
+| Property testing | QuickCheck | Integrated shrinking or state-machine testing makes Hedgehog a better fit |
+| Golden testing | tasty-golden | Semantic assertions express the requirement more clearly |
+| Tiny dependency-free teaching example | Manual assertions | The example is meant to demonstrate a realistic project test stack |
+
+## Explore the ecosystem
+
+### Core runners and assertions
+
+- [Tasty](https://hackage.haskell.org/package/tasty)
+- [Hspec](https://hspec.github.io/)
+- [HUnit](https://hackage.haskell.org/package/HUnit)
+- [tasty-hunit](https://hackage.haskell.org/package/tasty-hunit)
+
+### Property testing
+
+- [QuickCheck](https://hackage.haskell.org/package/QuickCheck)
+- [Hedgehog](https://hackage.haskell.org/package/hedgehog)
+- [tasty-quickcheck](https://hackage.haskell.org/package/tasty-quickcheck)
+- [tasty-hedgehog](https://hackage.haskell.org/package/tasty-hedgehog)
+- [hspec-hedgehog](https://hackage.haskell.org/package/hspec-hedgehog)
+
+### Golden and process testing
+
+- [tasty-golden](https://hackage.haskell.org/package/tasty-golden)
+- [tasty-program](https://hackage.haskell.org/package/tasty-program)
+
+### Broader discovery
+
+- [Hackage Testing category](https://hackage.haskell.org/packages/#cat:Testing)
+- [Legacy Awesome Haskell development tools](../README.md#development-tools)
+
+## Evidence used for this review
+
+- [Tasty package documentation](https://hackage.haskell.org/package/tasty)
+- [Hspec documentation](https://hspec.github.io/)
+- [HUnit package documentation](https://hackage.haskell.org/package/HUnit)
+- [QuickCheck package documentation](https://hackage.haskell.org/package/QuickCheck)
+- [Hedgehog package documentation](https://hackage.haskell.org/package/hedgehog)
+- [tasty-golden package documentation](https://hackage.haskell.org/package/tasty-golden)
+
+## Review notes
+
+This guide intentionally recommends a small default stack while preserving credible alternatives. It should be reviewed when major runner APIs, property-testing models, or compiler compatibility change. Specialized packages should not become highlighted recommendations without a defined use case, trade-offs, and current evidence.


### PR DESCRIPTION
## Summary

This PR adds the second pilot area for the Awesome Haskell redesign: choosing and applying a Haskell testing stack.

## Included

- `guides/testing.md` with a task-oriented comparison of:
  - Tasty, Hspec, and HUnit;
  - QuickCheck and Hedgehog;
  - golden tests and integration-test boundaries;
- an updated `examples/beginner-cli` test suite using:
  - Tasty as the runner;
  - tasty-hunit for concrete examples;
  - tasty-quickcheck for an explicit generated property;
- structured recommendation records for Tasty, Hspec, QuickCheck, and Hedgehog;
- navigation updates in `README.next.md`.

## Default recommendation

For a new general-purpose project, the guide recommends:

> Tasty + tasty-hunit + tasty-quickcheck

This is a scoped default rather than a universal ranking. Hspec is documented as a strong alternative for spec-oriented suites, while Hedgehog is documented as an alternative when integrated shrinking or state-machine testing is central.

## Verification

The updated example passed the complete GitHub Actions matrix on both configured compiler lines:

- GHC 9.12: setup, dependency resolution, build, tests, and executable run passed;
- GHC 9.14: setup, dependency resolution, build, tests, and executable run passed.

The property generator deliberately produces non-empty alphabetic words instead of unconstrained strings. Failure output includes the generated rendered greeting as a counterexample annotation.

## Review notes

- Tasty and QuickCheck are recommended only for defined starter use cases.
- Hspec and Hedgehog are presented as credible alternatives with explicit decision criteria.
- HUnit's low release frequency is not treated as automatic evidence of abandonment.
- Golden tests are described as regression tools, not proof of semantic correctness.
- The existing public `README.md` remains unchanged.

## Checklist

- [x] Add the testing decision guide
- [x] Compare runners and property-testing approaches
- [x] Add explicit trade-offs and decision criteria
- [x] Update the runnable example
- [x] Add structured recommendation records
- [x] Link the pilot from `README.next.md`
- [x] Confirm the updated dependency stack passes CI on GHC 9.12 and 9.14
- [x] Review generated-data quality and failure output

This PR does not activate `README.next.md` as the public repository entry point.