### PR TITLE
Validate structured recommendation data

### DIFF
--- a/.github/workflows/validate-data.yml
+++ b/.github/workflows/validate-data.yml
@@ -1,0 +1,41 @@
+name: Validate structured data
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "data/**"
+      - "schema/**"
+      - "scripts/validate_data.py"
+      - ".github/workflows/validate-data.yml"
+  pull_request:
+    paths:
+      - "data/**"
+      - "schema/**"
+      - "scripts/validate_data.py"
+      - ".github/workflows/validate-data.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install validator dependencies
+        run: python -m pip install "jsonschema[format]>=4.23,<5" "PyYAML>=6,<7"
+
+      - name: Validate YAML entries
+        run: python scripts/validate_data.py

--- a/schema/README.md
+++ b/schema/README.md
@@ -1,0 +1,26 @@
+# Structured entry validation
+
+The files under `data/` are an experimental machine-readable representation of reviewed Awesome Haskell entries.
+
+`entry.schema.json` defines the current pilot contract. It checks:
+
+- required identity and classification fields;
+- allowed kinds, roles, recommendation levels, and maintenance statuses;
+- ISO review dates and HTTPS URLs;
+- non-empty recommendation, trade-off, alternative, evidence, and reviewer lists;
+- the additional fields required for reviewed recommendations;
+- accidental recommendation-only fields on discovery entries;
+- unknown fields, which usually indicate a typo or an undocumented schema change.
+
+Run validation locally with:
+
+```sh
+python -m pip install "jsonschema[format]>=4.23,<5" "PyYAML>=6,<7"
+python scripts/validate_data.py
+```
+
+The same command runs in `.github/workflows/validate-data.yml` whenever structured data, the schema, or the validator changes.
+
+The schema validates structure, not editorial truth. Passing validation does not prove that a recommendation is correct, that a project is maintained, or that cited evidence supports a claim. Those remain human review responsibilities.
+
+This remains a pilot. After several categories use the format, the project should decide whether the schema provides enough value to justify the maintenance cost. If not, both `data/` and `schema/` can be removed without affecting the Haskell examples or Markdown guides.

--- a/schema/entry.schema.json
+++ b/schema/entry.schema.json
@@ -1,0 +1,146 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/krispo/awesome-haskell/schema/entry.schema.json",
+  "title": "Awesome Haskell entry",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "name",
+    "kind",
+    "category",
+    "url",
+    "summary",
+    "role",
+    "last_reviewed"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "name": {"type": "string", "minLength": 1},
+    "kind": {
+      "enum": [
+        "project",
+        "package",
+        "documentation",
+        "course",
+        "book",
+        "article",
+        "community",
+        "index",
+        "production-case-study"
+      ]
+    },
+    "category": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+    },
+    "url": {
+      "type": "string",
+      "format": "uri",
+      "pattern": "^https://"
+    },
+    "summary": {"type": "string", "minLength": 10},
+    "role": {"enum": ["discovery", "recommendation"]},
+    "recommendation": {
+      "enum": ["recommended", "alternative", "experimental", "historical"]
+    },
+    "maintenance_status": {
+      "enum": [
+        "active",
+        "stable",
+        "experimental",
+        "maintenance-mode",
+        "historical",
+        "archived",
+        "unknown"
+      ]
+    },
+    "recommended_for": {"$ref": "#/$defs/nonEmptyStringList"},
+    "consider_alternatives_when": {"$ref": "#/$defs/nonEmptyStringList"},
+    "tradeoffs": {"$ref": "#/$defs/nonEmptyStringList"},
+    "alternatives": {"$ref": "#/$defs/nonEmptyStringList"},
+    "evidence": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type", "url", "supports"],
+        "properties": {
+          "type": {
+            "enum": [
+              "official-documentation",
+              "release-notes",
+              "repository",
+              "compatibility",
+              "maintainer-statement",
+              "production-report",
+              "ci",
+              "other"
+            ]
+          },
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "pattern": "^https://"
+          },
+          "supports": {"type": "string", "minLength": 10}
+        }
+      }
+    },
+    "last_reviewed": {"type": "string", "format": "date"},
+    "reviewers": {"$ref": "#/$defs/nonEmptyStringList"},
+    "affiliation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reviewer", "relationship"],
+      "properties": {
+        "reviewer": {"type": "string", "minLength": 1},
+        "relationship": {"type": "string", "minLength": 1}
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {"role": {"const": "recommendation"}},
+        "required": ["role"]
+      },
+      "then": {
+        "required": [
+          "recommendation",
+          "maintenance_status",
+          "recommended_for",
+          "consider_alternatives_when",
+          "tradeoffs",
+          "alternatives",
+          "evidence",
+          "reviewers"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {"role": {"const": "discovery"}},
+        "required": ["role"]
+      },
+      "then": {
+        "not": {
+          "anyOf": [
+            {"required": ["recommendation"]},
+            {"required": ["recommended_for"]},
+            {"required": ["consider_alternatives_when"]},
+            {"required": ["tradeoffs"]}
+          ]
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "nonEmptyStringList": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"type": "string", "minLength": 1}
+    }
+  }
+}

--- a/scripts/validate_data.py
+++ b/scripts/validate_data.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Validate structured Awesome Haskell entries against the repository schema."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+from jsonschema import Draft202012Validator, FormatChecker
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = ROOT / "schema" / "entry.schema.json"
+DATA_ROOT = ROOT / "data"
+
+
+def load_yaml(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def format_path(parts: list[Any]) -> str:
+    if not parts:
+        return "<root>"
+    rendered = ""
+    for part in parts:
+        if isinstance(part, int):
+            rendered += f"[{part}]"
+        else:
+            rendered += ("." if rendered else "") + str(part)
+    return rendered
+
+
+def main() -> int:
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    validator = Draft202012Validator(schema, format_checker=FormatChecker())
+    files = sorted(DATA_ROOT.rglob("*.yaml"))
+
+    if not files:
+        print("No YAML entries found under data/.", file=sys.stderr)
+        return 1
+
+    failures = 0
+    for path in files:
+        relative = path.relative_to(ROOT)
+        try:
+            document = load_yaml(path)
+        except yaml.YAMLError as error:
+            failures += 1
+            print(f"{relative}: invalid YAML: {error}", file=sys.stderr)
+            continue
+
+        errors = sorted(
+            validator.iter_errors(document),
+            key=lambda error: list(error.absolute_path),
+        )
+        if errors:
+            failures += 1
+            for error in errors:
+                location = format_path(list(error.absolute_path))
+                print(f"{relative}:{location}: {error.message}", file=sys.stderr)
+        else:
+            print(f"OK {relative}")
+
+    if failures:
+        print(f"Validation failed for {failures} file(s).", file=sys.stderr)
+        return 1
+
+    print(f"Validated {len(files)} structured entry file(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_data.py
+++ b/scripts/validate_data.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import sys
+from datetime import date, datetime
 from pathlib import Path
 from typing import Any
 
@@ -16,9 +17,20 @@ SCHEMA_PATH = ROOT / "schema" / "entry.schema.json"
 DATA_ROOT = ROOT / "data"
 
 
+def normalize_yaml_values(value: Any) -> Any:
+    """Convert YAML-native date values into the ISO strings used by the schema."""
+    if isinstance(value, (date, datetime)):
+        return value.isoformat()
+    if isinstance(value, list):
+        return [normalize_yaml_values(item) for item in value]
+    if isinstance(value, dict):
+        return {key: normalize_yaml_values(item) for key, item in value.items()}
+    return value
+
+
 def load_yaml(path: Path) -> Any:
     with path.open("r", encoding="utf-8") as handle:
-        return yaml.safe_load(handle)
+        return normalize_yaml_values(yaml.safe_load(handle))
 
 
 def format_path(parts: list[Any]) -> str:


### PR DESCRIPTION
## Summary

This PR turns the experimental `data/` directory into a validated pilot rather than an unchecked collection of YAML files.

## Included

- `schema/entry.schema.json` — JSON Schema for structured entries;
- `scripts/validate_data.py` — local validator with readable file and field errors;
- `.github/workflows/validate-data.yml` — CI validation for changes to data, schema, or validator;
- `schema/README.md` — scope, local usage, and limitations.

## What validation checks

- required identity and classification fields;
- allowed kinds, roles, recommendation levels, and maintenance statuses;
- HTTPS URLs and ISO review dates;
- non-empty use-case, trade-off, alternative, evidence, and reviewer lists;
- additional fields required for reviewed recommendations;
- accidental recommendation-only fields on discovery records;
- unknown fields that may be typos or undocumented schema changes.

## What validation does not check

Passing validation does not prove that a recommendation is correct, current, or supported by its citations. Editorial judgement and evidence review remain human responsibilities.

## Verification

The GitHub Actions validation job passed successfully. It checked every YAML file currently under `data/` against the schema.

The validator also normalizes YAML-native date objects into ISO strings before schema validation, preventing valid unquoted dates such as `2026-08-02` from failing type checks.

## Reversibility

This remains experimental. If structured data does not prove useful after several pilot categories, `data/`, `schema/`, the validator, and its workflow can be removed without affecting the Haskell examples or Markdown guides.

## Checklist

- [x] Add the schema
- [x] Add a local validator
- [x] Add CI configuration
- [x] Document scope and removal path
- [x] Confirm all current YAML entries pass validation

This PR must not be merged automatically.