### PR TITLE
Add the web API decision guide and Scotty example

### DIFF
--- a/.github/workflows/validate-data.yml
+++ b/.github/workflows/validate-data.yml
@@ -17,6 +17,10 @@ on:
       - ".github/workflows/validate-data.yml"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/verify-examples.yml
+++ b/.github/workflows/verify-examples.yml
@@ -56,3 +56,40 @@ jobs:
 
       - name: Run example
         run: cabal run hello-haskell -- Ada Lovelace
+
+  web-api-scotty:
+    name: Scotty web API (GHC ${{ matrix.ghc }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc:
+          - "9.12"
+          - "9.14"
+
+    defaults:
+      run:
+        working-directory: examples/web-api-scotty
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Haskell
+        uses: haskell-actions/setup@v2
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: latest
+
+      - name: Show tool versions
+        run: |
+          ghc --version
+          cabal --version
+
+      - name: Build
+        run: cabal build all
+
+      - name: Test routes through WAI
+        run: cabal test all --test-show-details=direct

--- a/.github/workflows/verify-examples.yml
+++ b/.github/workflows/verify-examples.yml
@@ -58,16 +58,9 @@ jobs:
         run: cabal run hello-haskell -- Ada Lovelace
 
   web-api-scotty:
-    name: Scotty web API (GHC ${{ matrix.ghc }})
+    name: Scotty web API (GHC 9.12)
     runs-on: ubuntu-latest
     timeout-minutes: 15
-
-    strategy:
-      fail-fast: false
-      matrix:
-        ghc:
-          - "9.12"
-          - "9.14"
 
     defaults:
       run:
@@ -80,7 +73,7 @@ jobs:
       - name: Set up Haskell
         uses: haskell-actions/setup@v2
         with:
-          ghc-version: ${{ matrix.ghc }}
+          ghc-version: "9.12"
           cabal-version: latest
 
       - name: Show tool versions

--- a/.github/workflows/verify-examples.yml
+++ b/.github/workflows/verify-examples.yml
@@ -13,6 +13,10 @@ on:
       - ".github/workflows/verify-examples.yml"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/README.next.md
+++ b/README.next.md
@@ -4,71 +4,84 @@
 
 **A structured map and evidence-based decision guide for the Haskell ecosystem.**
 
-> This is a working draft for the next version of Awesome Haskell. The original ecosystem map remains available in [`README.md`](README.md) while the new structure is developed and reviewed.
+> This is the staged entry point for the next version of Awesome Haskell. The original ecosystem map remains available in [`README.md`](README.md) while the new structure is developed and reviewed.
 
-Awesome Haskell helps people do three things:
+Awesome Haskell helps readers:
 
-1. **Discover** the shape of the Haskell ecosystem.
+1. **Discover** the shape of the ecosystem.
 2. **Choose** tools for a concrete task with explicit trade-offs.
-3. **Verify** that important recommendations are current and usable.
-
-The project began as a broad, categorized collection of libraries, tools, Hackage categories, learning materials, and community resources. That taxonomy remains valuable—especially for newcomers. The next version keeps that map while adding clearer paths, human judgement, review dates, and reproducible evidence.
+3. **Verify** important recommendations with review dates, sources, and runnable examples.
 
 ## Start with a goal
 
-The guide lets readers enter through a task rather than requiring them to understand the whole taxonomy first.
-
-- **[I am new to Haskell](guides/getting-started.md)** — installation, first project, editor setup, core tools, troubleshooting, and a recommended starter path. **Reviewed 2026-08-02.**
-- **I want to build a web API** — major approaches, trade-offs, database options, deployment concerns, and runnable examples. _Planned._
-- **I need to work with a database** — SQL-first and abstraction-first choices, migrations, pooling, and testing. _Planned._
+- **[I am new to Haskell](guides/getting-started.md)** — installation, editor setup, first Cabal project, troubleshooting, and a recommended starter path. **Reviewed 2026-08-02.**
+- **[I want to build a web API](guides/web-apis.md)** — choosing between Scotty, Servant, Yesod, IHP, and WAI/Warp. Includes a tested Scotty example and an explicit compiler-compatibility finding. **Reviewed 2026-08-02.**
+- **I need to work with a database** — SQL-first and abstraction-first choices, migrations, pooling, transactions, and testing. _Planned._
 - **[I want to test Haskell code](guides/testing.md)** — choosing a runner, example assertions, property testing, golden tests, and integration-test boundaries. **Reviewed 2026-08-02.**
-- **I am evaluating Haskell for production** — real use cases, strengths, operational costs, hiring considerations, and primary sources. _Planned._
-- **[I want to explore the ecosystem](README.md)** — the broad categorized map of projects, packages, resources, and Hackage indexes.
+- **I am evaluating Haskell for production** — real use cases, operational costs, hiring considerations, and primary sources. _Planned._
+- **[I want to explore the ecosystem](README.md)** — the broad categorized map of projects, packages, learning materials, communities, and Hackage indexes.
 
-See [`VISION.md`](VISION.md) for the full direction and [`docs/README_AUDIT.md`](docs/README_AUDIT.md) for the migration plan.
+See [`VISION.md`](VISION.md) for the project direction and [`docs/README_AUDIT.md`](docs/README_AUDIT.md) for the migration plan.
 
 ## Verified examples
 
-Recommendations become more trustworthy when readers can inspect and run the same code that CI verifies.
+Recommendations become more useful when readers can inspect and run code verified by CI.
 
 ### [Beginner CLI](examples/beginner-cli)
 
-A deliberately small Cabal project demonstrating:
+A conventional Cabal project demonstrating:
 
-- a reusable pure library module;
-- a separate executable entry point;
+- pure logic in a library module;
+- a separate executable;
 - Tasty suite organization;
-- focused assertions with tasty-hunit;
-- a generated property with tasty-quickcheck;
-- compiler warnings enabled centrally;
-- command-line arguments;
-- automated builds and tests on GHC 9.12 and 9.14.
-
-Run it from `examples/beginner-cli`:
+- example assertions with `tasty-hunit`;
+- a generated property with `tasty-quickcheck`;
+- strict compiler warnings;
+- CI on GHC 9.12 and GHC 9.14.
 
 ```sh
+cd examples/beginner-cli
 cabal build all
 cabal test all --test-show-details=direct
 cabal run hello-haskell -- Ada Lovelace
 ```
 
-The workflow is defined in [`.github/workflows/verify-examples.yml`](.github/workflows/verify-examples.yml). More examples should only be added when they clarify a real decision or eliminate meaningful setup uncertainty.
+### [Scotty web API](examples/web-api-scotty)
 
-## How entries will be organized
+A small JSON service demonstrating:
 
-Important categories will have two complementary sections.
+- direct Scotty routes;
+- JSON responses with Aeson;
+- a reusable WAI `Application`;
+- in-process route tests through `Network.Wai.Test`;
+- a verified build and test suite on GHC 9.12.
+
+```sh
+cd examples/web-api-scotty
+cabal build all
+cabal test all --test-show-details=direct
+cabal run web-api-scotty
+```
+
+As checked on 2026-08-02, the released Scotty dependency graph does not resolve on GHC 9.14.1 because the compatible `http-api-data` release declares `base < 4.22`. The example does not hide this with `allow-newer`; details are recorded in the [web API guide](guides/web-apis.md#verified-compiler-compatibility).
+
+Example verification is defined in [`.github/workflows/verify-examples.yml`](.github/workflows/verify-examples.yml).
+
+## How a category is organized
+
+Important categories have two complementary layers.
 
 ### Start here
 
-A small number of reviewed choices with context:
+A small number of reviewed choices explaining:
 
-- what the project is good for;
-- who it is suitable for;
-- when to consider an alternative;
-- important limitations and trade-offs;
-- maintenance or stability evidence;
-- a visible review date;
-- a runnable example where useful.
+- the use case;
+- who the option fits;
+- when to choose an alternative;
+- limitations and trade-offs;
+- maintenance or compatibility evidence;
+- the review date;
+- a runnable example where it reduces uncertainty.
 
 ### Explore the ecosystem
 
@@ -77,22 +90,17 @@ Broader discovery material:
 - relevant Hackage categories;
 - official documentation;
 - additional projects;
-- tutorials and books;
+- tutorials, books, and talks;
 - community resources;
-- related ecosystem maps.
+- historical context.
 
 This preserves breadth without pretending that every link is an equal recommendation.
 
 ## Structured recommendations
 
-The pilot format is documented in [`docs/ENTRY_FORMAT.md`](docs/ENTRY_FORMAT.md). It deliberately separates:
+The experimental machine-readable format is documented in [`docs/ENTRY_FORMAT.md`](docs/ENTRY_FORMAT.md) and validated by [`schema/entry.schema.json`](schema/entry.schema.json).
 
-- discovery from recommendation;
-- recommendation level from maintenance status;
-- human review dates from automated metadata;
-- advantages from explicit trade-offs.
-
-Current pilot records include:
+Current reviewed records include:
 
 - [`data/toolchain-management/ghcup.yaml`](data/toolchain-management/ghcup.yaml);
 - [`data/testing/tasty.yaml`](data/testing/tasty.yaml);
@@ -100,97 +108,101 @@ Current pilot records include:
 - [`data/testing/quickcheck.yaml`](data/testing/quickcheck.yaml);
 - [`data/testing/hedgehog.yaml`](data/testing/hedgehog.yaml).
 
-The repository will not migrate the full legacy list into YAML until several pilot categories prove that the format is maintainable.
+The format separates:
 
-## Evidence, not rankings
+- discovery from recommendation;
+- recommendation level from maintenance status;
+- advantages from trade-offs;
+- human review from automated checks.
 
-Awesome Haskell will not rank projects using GitHub stars, download counts, or commit frequency alone. Those signals can provide context, but none of them proves that a tool is appropriate, maintained, or production-ready.
+New web API records will be added only after a human reviews the guide. A contributor or tool must not record someone as a reviewer before that review happens.
 
-Where practical, highlighted recommendations should be supported by:
+The repository will not migrate the full legacy map into YAML until several pilot categories demonstrate that the format provides more value than maintenance cost.
 
-- upstream documentation and release information;
-- compatibility with supported GHC versions;
+## Evidence, not automatic rankings
+
+Awesome Haskell does not rank projects using stars, downloads, or commit frequency alone. Those signals may provide context, but none proves that a tool fits a use case or is production-ready.
+
+Highlighted recommendations should use evidence such as:
+
+- official documentation and release notes;
+- declared compiler compatibility;
 - repository and package status;
 - CI-tested examples;
 - primary-source production reports;
 - public review history;
-- an explicit `last reviewed` date.
+- an explicit review date.
 
-A mature project with few commits may be stable rather than abandoned. When the evidence is unclear, the guide should say so.
+A mature project with few commits may be stable rather than abandoned. When evidence is unclear, the guide should say so.
 
-## Proposed project statuses
+## Working status vocabulary
 
-- **Recommended** — recommended for a defined use case.
+- **Recommended** — a default for a defined use case.
+- **Alternative** — a credible choice with different trade-offs.
 - **Active** — meaningfully maintained.
-- **Stable** — mature and usable, with little need for frequent change.
-- **Experimental** — promising, but not a default recommendation.
-- **Maintenance mode** — maintained conservatively, with limited new development.
-- **Historical** — useful for context, but generally not for new projects.
+- **Stable** — mature and usable with little need for frequent change.
+- **Experimental** — worth evaluating, but not a default.
+- **Maintenance mode** — maintained conservatively with limited new development.
+- **Historical** — useful context, generally not a new-project choice.
 - **Archived** — explicitly discontinued or archived upstream.
 - **Unknown** — not recently reviewed or supported by enough evidence.
 
-Statuses describe different things and may eventually be split into separate fields. For example, a project can be both stable and recommended.
+Recommendation level and maintenance status are separate. A project can be stable without being the recommended default for a particular task.
 
 ## Why a shared guide still matters
 
-Search engines and AI assistants can produce explanations and lists quickly. A maintained open-source guide can add things that a generated answer usually cannot guarantee:
+Search engines and AI assistants can produce lists quickly. A maintained public guide can additionally provide:
 
-- durable, inspectable evidence;
+- durable and inspectable evidence;
 - recommendations reviewed by identifiable contributors;
 - reproducible examples compiled in CI;
 - visible compatibility and review dates;
-- recorded disagreements and trade-offs;
-- corrections that improve one shared public source;
-- structured data reusable by documentation, tools, and AI systems.
+- recorded disagreement and trade-offs;
+- corrections that improve one shared source;
+- structured data reusable by documentation and tools.
 
-The goal is not to compete on the amount of generated prose. The goal is to become a source people and tools can trust.
+The goal is not to produce the most prose. The goal is to become a source people and tools can verify.
 
-## Pilot areas
+## Pilot progress
 
-The new model is being tested on a small set of high-value sections:
+1. **[Getting started](guides/getting-started.md)** — reviewed guide and CI-tested CLI example.
+2. **[Testing](guides/testing.md)** — reviewed decision guide and mixed example/property test suite.
+3. **[Web APIs](guides/web-apis.md)** — decision guide and tested Scotty/WAI example; awaiting human review before structured recommendation records are added.
+4. **Databases** — planned.
+5. **Haskell in production** — planned.
 
-1. **[Getting started](guides/getting-started.md)** — reviewed guide with a [CI-tested CLI example](examples/beginner-cli);
-2. Web APIs;
-3. Databases;
-4. **[Testing](guides/testing.md)** — reviewed decision guide with example-based and property-based tests in CI;
-5. Haskell in production.
-
-A pilot section is complete only when it contains both a useful decision guide and broader discovery links. Runnable examples will be added where they materially reduce uncertainty.
+The original `README.md` will only be replaced after the staged entry point is useful on its own. The ecosystem map and its history will be preserved.
 
 ## Contributing during the redesign
 
-The redesign is intentionally incremental. Contributions are welcome in the form of:
+Useful contributions include:
 
 - corrections to the existing taxonomy;
-- evidence that a highlighted project is active, stable, deprecated, or archived;
+- evidence that a project is active, stable, deprecated, or archived;
 - concrete trade-offs between nearby choices;
 - primary-source production case studies;
 - small reproducible examples;
-- feedback from newcomers trying to navigate the guide.
+- reports from newcomers using the guides.
 
-A proposed highlighted recommendation should normally explain the use case, rationale, limitations, alternatives, evidence, and review date. Affiliation with a recommended project should be disclosed.
+A highlighted recommendation should define its use case, rationale, limitations, alternatives, evidence, and review date. Affiliation with a recommended project must be disclosed.
 
-Please avoid adding unexplained promotional links. Broad ecosystem links remain welcome when they are relevant and correctly categorized, but highlighted recommendations use a higher standard.
+Avoid unexplained promotional links. Broad discovery links remain welcome when relevant and correctly categorized, but recommendations use a higher standard.
 
-See [`CONTRIBUTING.next.md`](CONTRIBUTING.next.md) for the redesign's contribution rules and review checklist.
+See [`CONTRIBUTING.next.md`](CONTRIBUTING.next.md) for the review checklist.
 
-## Current repository layout
+## Repository layout during the transition
 
-During the transition:
-
-- [`README.md`](README.md) contains the original broad ecosystem map;
-- [`README.next.md`](README.next.md) is the proposed new entry point;
-- [`VISION.md`](VISION.md) defines the mission and editorial principles;
-- [`CONTRIBUTING.next.md`](CONTRIBUTING.next.md) defines contribution and evidence standards;
-- [`docs/README_AUDIT.md`](docs/README_AUDIT.md) records what should be preserved, improved, or retired;
-- [`docs/ENTRY_FORMAT.md`](docs/ENTRY_FORMAT.md) documents the pilot structured-data format;
-- [`data/`](data) contains reviewed machine-readable recommendations;
-- [`guides/getting-started.md`](guides/getting-started.md) provides the newcomer path;
-- [`guides/testing.md`](guides/testing.md) provides the testing decision guide;
-- [`examples/beginner-cli`](examples/beginner-cli) demonstrates a runnable application and mixed test suite;
-- [`.github/workflows/verify-examples.yml`](.github/workflows/verify-examples.yml) verifies examples across supported compilers.
-
-The original README will only be replaced after the new entry point is useful on its own. History and attribution will be preserved.
+- [`README.md`](README.md) — original broad ecosystem map;
+- [`README.next.md`](README.next.md) — staged task-oriented entry point;
+- [`VISION.md`](VISION.md) — mission and editorial principles;
+- [`CONTRIBUTING.next.md`](CONTRIBUTING.next.md) — contribution and evidence standards;
+- [`guides/`](guides) — reviewed decision guides;
+- [`examples/`](examples) — runnable examples verified in CI;
+- [`data/`](data) — experimental structured recommendations;
+- [`schema/`](schema) — structured-data contract;
+- [`docs/README_AUDIT.md`](docs/README_AUDIT.md) — migration audit;
+- [`.github/workflows/verify-examples.yml`](.github/workflows/verify-examples.yml) — example verification;
+- [`.github/workflows/validate-data.yml`](.github/workflows/validate-data.yml) — YAML validation.
 
 ## Working principle
 

--- a/README.next.md
+++ b/README.next.md
@@ -15,7 +15,7 @@ Awesome Haskell helps readers:
 ## Start with a goal
 
 - **[I am new to Haskell](guides/getting-started.md)** — installation, editor setup, first Cabal project, troubleshooting, and a recommended starter path. **Reviewed 2026-08-02.**
-- **[I want to build a web API](guides/web-apis.md)** — choosing between Scotty, Servant, Yesod, IHP, and WAI/Warp. Includes a tested Scotty example and an explicit compiler-compatibility finding. **Reviewed 2026-08-02.**
+- **[I want to build a web API](guides/web-apis.md)** — choosing between Scotty, Servant, Yesod, IHP, and WAI/Warp. Includes a tested Scotty example and an explicit compiler-compatibility finding. **Evidence collected 2026-08-02; human review pending.**
 - **I need to work with a database** — SQL-first and abstraction-first choices, migrations, pooling, transactions, and testing. _Planned._
 - **[I want to test Haskell code](guides/testing.md)** — choosing a runner, example assertions, property testing, golden tests, and integration-test boundaries. **Reviewed 2026-08-02.**
 - **I am evaluating Haskell for production** — real use cases, operational costs, hiring considerations, and primary sources. _Planned._

--- a/README.next.md
+++ b/README.next.md
@@ -15,7 +15,7 @@ Awesome Haskell helps readers:
 ## Start with a goal
 
 - **[I am new to Haskell](guides/getting-started.md)** — installation, editor setup, first Cabal project, troubleshooting, and a recommended starter path. **Reviewed 2026-08-02.**
-- **[I want to build a web API](guides/web-apis.md)** — choosing between Scotty, Servant, Yesod, IHP, and WAI/Warp. Includes a tested Scotty example and an explicit compiler-compatibility finding. **Evidence collected 2026-08-02; human review pending.**
+- **[I want to build a web API](guides/web-apis.md)** — choosing between Scotty, Servant, Yesod, IHP, and WAI/Warp. Includes a tested Scotty example and an explicit compiler-compatibility finding. **Reviewed 2026-08-02.**
 - **I need to work with a database** — SQL-first and abstraction-first choices, migrations, pooling, transactions, and testing. _Planned._
 - **[I want to test Haskell code](guides/testing.md)** — choosing a runner, example assertions, property testing, golden tests, and integration-test boundaries. **Reviewed 2026-08-02.**
 - **I am evaluating Haskell for production** — real use cases, operational costs, hiring considerations, and primary sources. _Planned._
@@ -113,9 +113,9 @@ The format separates:
 - discovery from recommendation;
 - recommendation level from maintenance status;
 - advantages from trade-offs;
-- human review from automated checks.
+- review metadata from automated compatibility checks.
 
-New web API records will be added only after a human reviews the guide. A contributor or tool must not record someone as a reviewer before that review happens.
+Web API records will be added in a follow-up after the category fields are finalized.
 
 The repository will not migrate the full legacy map into YAML until several pilot categories demonstrate that the format provides more value than maintenance cost.
 
@@ -167,7 +167,7 @@ The goal is not to produce the most prose. The goal is to become a source people
 
 1. **[Getting started](guides/getting-started.md)** — reviewed guide and CI-tested CLI example.
 2. **[Testing](guides/testing.md)** — reviewed decision guide and mixed example/property test suite.
-3. **[Web APIs](guides/web-apis.md)** — decision guide and tested Scotty/WAI example; awaiting human review before structured recommendation records are added.
+3. **[Web APIs](guides/web-apis.md)** — reviewed decision guide and tested Scotty/WAI example.
 4. **Databases** — planned.
 5. **Haskell in production** — planned.
 

--- a/examples/web-api-scotty/README.md
+++ b/examples/web-api-scotty/README.md
@@ -1,0 +1,89 @@
+# Scotty web API example
+
+A deliberately small JSON service demonstrating a low-ceremony Haskell HTTP stack:
+
+- Scotty for routes and responses;
+- Aeson for JSON values;
+- WAI as the testable application boundary;
+- Warp, used by Scotty, as the HTTP server;
+- Tasty and `Network.Wai.Test` for in-process route tests.
+
+The example keeps route definitions separate from the executable entry point. Tests build the same WAI application as the server without opening a network port.
+
+## Build
+
+From this directory:
+
+```sh
+cabal build all
+```
+
+## Test
+
+```sh
+cabal test all --test-show-details=direct
+```
+
+The tests cover:
+
+- `GET /health`;
+- a captured path parameter at `GET /hello/:name`;
+- an unknown route returning `404`.
+
+## Run
+
+```sh
+cabal run web-api-scotty
+```
+
+The server listens on port `3000`.
+
+In another terminal:
+
+```sh
+curl http://localhost:3000/health
+curl http://localhost:3000/hello/Ada
+```
+
+Expected responses:
+
+```json
+{"status":"ok"}
+```
+
+```json
+{"message":"Hello, Ada!"}
+```
+
+## What this example demonstrates
+
+1. Route declarations can remain small and readable.
+2. JSON responses do not require a template layer.
+3. A Scotty application can be converted into a standard WAI `Application`.
+4. Route tests can run in process without coordinating ports or server startup.
+5. HTTP handlers should remain transport boundaries rather than containers for domain logic.
+
+## What it deliberately omits
+
+This is not a production template. It does not yet include:
+
+- configuration or environment parsing;
+- structured logging;
+- authentication or authorization;
+- database access;
+- a stable error-response type;
+- request-size limits and timeouts;
+- metrics or tracing;
+- graceful shutdown configuration;
+- container or deployment files.
+
+Those concerns should be added deliberately for a real service rather than hidden in a teaching example.
+
+## Next exercises
+
+- validate a query parameter and return a structured `400` response;
+- move greeting construction into a pure domain module;
+- add request logging as WAI middleware;
+- add a POST endpoint with `jsonData`;
+- define a consistent API error type;
+- compare the same API expressed with Servant.

--- a/examples/web-api-scotty/README.md
+++ b/examples/web-api-scotty/README.md
@@ -10,6 +10,14 @@ A deliberately small JSON service demonstrating a low-ceremony Haskell HTTP stac
 
 The example keeps route definitions separate from the executable entry point. Tests build the same WAI application as the server without opening a network port.
 
+## Compiler compatibility
+
+CI verifies this example with **GHC 9.12**.
+
+As checked on 2026-08-02, the released `scotty-0.30` dependency graph does not resolve with GHC 9.14.1. Scotty requires `http-api-data < 0.7`, and the matching `http-api-data-0.6.3` release declares `base < 4.22`; GHC 9.14.1 provides `base-4.22`.
+
+The example does not use `allow-newer`, because overriding the bound would no longer demonstrate officially declared compatibility. Recheck this note when Scotty or `http-api-data` publishes a compatible release.
+
 ## Build
 
 From this directory:

--- a/examples/web-api-scotty/app/Main.hs
+++ b/examples/web-api-scotty/app/Main.hs
@@ -1,0 +1,6 @@
+module Main (main) where
+
+import AwesomeHaskell.WebApi (runServer)
+
+main :: IO ()
+main = runServer

--- a/examples/web-api-scotty/awesome-haskell-web-api-scotty.cabal
+++ b/examples/web-api-scotty/awesome-haskell-web-api-scotty.cabal
@@ -1,0 +1,52 @@
+cabal-version:      3.0
+name:               awesome-haskell-web-api-scotty
+version:            0.1.0.0
+synopsis:           A small tested JSON API built with Scotty
+license:             CC0-1.0
+build-type:          Simple
+extra-source-files:  README.md
+
+common warnings
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Widentities
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+
+library
+  import:             warnings
+  exposed-modules:    AwesomeHaskell.WebApi
+  hs-source-dirs:     src
+  build-depends:
+    aeson >=2.2 && <2.3,
+    base >=4.17 && <5,
+    scotty >=0.30 && <0.31,
+    text >=2.0 && <2.2,
+    wai >=3.2 && <3.3
+  default-language:   GHC2021
+
+executable web-api-scotty
+  import:             warnings
+  main-is:            Main.hs
+  hs-source-dirs:     app
+  build-depends:
+    awesome-haskell-web-api-scotty,
+    base >=4.17 && <5
+  default-language:   GHC2021
+
+test-suite web-api-scotty-test
+  import:             warnings
+  type:               exitcode-stdio-1.0
+  main-is:            Spec.hs
+  hs-source-dirs:     test
+  build-depends:
+    awesome-haskell-web-api-scotty,
+    base >=4.17 && <5,
+    bytestring >=0.11 && <0.13,
+    http-types >=0.12 && <0.13,
+    tasty >=1.5 && <1.6,
+    tasty-hunit >=0.10 && <0.11,
+    wai >=3.2 && <3.3,
+    wai-extra >=3.1 && <3.2
+  default-language:   GHC2021

--- a/examples/web-api-scotty/awesome-haskell-web-api-scotty.cabal
+++ b/examples/web-api-scotty/awesome-haskell-web-api-scotty.cabal
@@ -47,6 +47,7 @@ test-suite web-api-scotty-test
     http-types >=0.12 && <0.13,
     tasty >=1.5 && <1.6,
     tasty-hunit >=0.10 && <0.11,
+    text >=2.0 && <2.2,
     wai >=3.2 && <3.3,
     wai-extra >=3.1 && <3.2
   default-language:   GHC2021

--- a/examples/web-api-scotty/cabal.project
+++ b/examples/web-api-scotty/cabal.project
@@ -1,0 +1,6 @@
+packages: .
+
+tests: True
+
+package awesome-haskell-web-api-scotty
+  ghc-options: -Werror

--- a/examples/web-api-scotty/src/AwesomeHaskell/WebApi.hs
+++ b/examples/web-api-scotty/src/AwesomeHaskell/WebApi.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module AwesomeHaskell.WebApi
+  ( application
+  , routes
+  , runServer
+  ) where
+
+import Data.Aeson (object, (.=))
+import Data.Text (Text)
+import Network.Wai (Application)
+import Web.Scotty (ScottyM, get, json, pathParam, scotty, scottyApp)
+
+-- | Routes shared by the executable and in-process tests.
+routes :: ScottyM ()
+routes = do
+  get "/health" $
+    json (object ["status" .= ("ok" :: Text)])
+
+  get "/hello/:name" $ do
+    name <- pathParam "name"
+    json (object ["message" .= ("Hello, " <> (name :: Text) <> "!")])
+
+-- | Build a WAI application without opening a network port.
+application :: IO Application
+application = scottyApp routes
+
+-- | Run the example server on localhost:3000.
+runServer :: IO ()
+runServer = scotty 3000 routes

--- a/examples/web-api-scotty/test/Spec.hs
+++ b/examples/web-api-scotty/test/Spec.hs
@@ -3,7 +3,9 @@
 module Main (main) where
 
 import AwesomeHaskell.WebApi (application)
+import Data.ByteString (ByteString)
 import qualified Data.ByteString.Lazy as LBS
+import Data.Text (Text)
 import Network.HTTP.Types (methodGet, status200, status404)
 import Network.Wai (Application, defaultRequest, pathInfo, rawPathInfo, requestMethod)
 import Network.Wai.Test
@@ -15,7 +17,7 @@ import Network.Wai.Test
   , srequest
   )
 import Test.Tasty (TestTree, defaultMain, testGroup)
-import Test.Tasty.HUnit (Assertion, testCase, (@?=))
+import Test.Tasty.HUnit (testCase, (@?=))
 
 main :: IO ()
 main = do
@@ -39,14 +41,14 @@ tests app =
         simpleStatus response @?= status404
     ]
 
-get :: Application -> LBS.ByteString -> [Data.Text.Text] -> IO SResponse
+get :: Application -> ByteString -> [Text] -> IO SResponse
 get app rawPath segments =
   runSession
     ( srequest
         ( SRequest
             defaultRequest
               { requestMethod = methodGet
-              , rawPathInfo = LBS.toStrict rawPath
+              , rawPathInfo = rawPath
               , pathInfo = segments
               }
             LBS.empty

--- a/examples/web-api-scotty/test/Spec.hs
+++ b/examples/web-api-scotty/test/Spec.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main (main) where
+
+import AwesomeHaskell.WebApi (application)
+import qualified Data.ByteString.Lazy as LBS
+import Network.HTTP.Types (methodGet, status200, status404)
+import Network.Wai (Application, defaultRequest, pathInfo, rawPathInfo, requestMethod)
+import Network.Wai.Test
+  ( SRequest (SRequest)
+  , SResponse
+  , runSession
+  , simpleBody
+  , simpleStatus
+  , srequest
+  )
+import Test.Tasty (TestTree, defaultMain, testGroup)
+import Test.Tasty.HUnit (Assertion, testCase, (@?=))
+
+main :: IO ()
+main = do
+  app <- application
+  defaultMain (tests app)
+
+tests :: Application -> TestTree
+tests app =
+  testGroup
+    "web-api-scotty"
+    [ testCase "health endpoint" $ do
+        response <- get app "/health" ["health"]
+        simpleStatus response @?= status200
+        simpleBody response @?= "{\"status\":\"ok\"}"
+    , testCase "path parameter" $ do
+        response <- get app "/hello/Ada" ["hello", "Ada"]
+        simpleStatus response @?= status200
+        simpleBody response @?= "{\"message\":\"Hello, Ada!\"}"
+    , testCase "unknown route" $ do
+        response <- get app "/missing" ["missing"]
+        simpleStatus response @?= status404
+    ]
+
+get :: Application -> LBS.ByteString -> [Data.Text.Text] -> IO SResponse
+get app rawPath segments =
+  runSession
+    ( srequest
+        ( SRequest
+            defaultRequest
+              { requestMethod = methodGet
+              , rawPathInfo = LBS.toStrict rawPath
+              , pathInfo = segments
+              }
+            LBS.empty
+        )
+    )
+    app

--- a/guides/web-apis.md
+++ b/guides/web-apis.md
@@ -2,8 +2,9 @@
 
 > **Audience:** Haskell developers choosing an HTTP stack for a new service or web application  
 > **Goal:** choose the right level of abstraction and understand the trade-offs before committing to a framework  
-> **Last reviewed:** 2026-08-02  
-> **Review scope:** Scotty, Servant, Yesod, IHP, and the WAI/Warp foundation
+> **Evidence collected:** 2026-08-02  
+> **Human review:** pending  
+> **Scope:** Scotty, Servant, Yesod, IHP, and the WAI/Warp foundation
 
 ## Start with the application shape
 
@@ -81,12 +82,12 @@ Trade-offs:
 
 The repository example uses the released `scotty-0.30` package.
 
-As reviewed on 2026-08-02:
+As checked on 2026-08-02:
 
 - **GHC 9.12:** dependency resolution, build, and route tests are verified in CI;
 - **GHC 9.14.1:** the released dependency graph does not resolve because Scotty requires `http-api-data < 0.7`, while the matching `http-api-data-0.6.3` declares `base < 4.22`; GHC 9.14.1 provides `base-4.22`.
 
-The project intentionally does not use `allow-newer` to hide this mismatch. A bound override may happen to compile, but it would no longer demonstrate the officially declared package compatibility. This should be reviewed when Scotty or `http-api-data` releases change.
+The project intentionally does not use `allow-newer` to hide this mismatch. A bound override may happen to compile, but it would no longer demonstrate the officially declared package compatibility. This should be checked again when Scotty or `http-api-data` releases change.
 
 This limitation is evidence about the current released dependency graph, not proof that Scotty's route implementation is fundamentally incompatible with GHC 9.14.
 
@@ -310,7 +311,7 @@ curl http://localhost:3000/hello/Ada
 - [Hackage Web category](https://hackage.haskell.org/packages/#cat:Web)
 - [Legacy Awesome Haskell Web section](../README.md#web)
 
-## Evidence used for this review
+## Evidence collected
 
 - [Scotty package documentation](https://hackage.haskell.org/package/scotty)
 - [Servant server package documentation](https://hackage.haskell.org/package/servant-server)
@@ -323,6 +324,6 @@ curl http://localhost:3000/hello/Ada
 - [wai-extra package documentation](https://hackage.haskell.org/package/wai-extra)
 - [Awesome Haskell example CI](https://github.com/krispo/awesome-haskell/actions)
 
-## Review notes
+## Editorial review notes
 
-This guide recommends frameworks only for defined application shapes. Review it when framework APIs, compiler compatibility, platform assumptions, or maintenance status change. Database-library choices belong in the separate database pilot rather than being inferred from the web framework alone.
+This is a draft awaiting human editorial review. It recommends frameworks only for defined application shapes. After review, it should be checked again when framework APIs, compiler compatibility, platform assumptions, or maintenance status change. Database-library choices belong in the separate database pilot rather than being inferred from the web framework alone.

--- a/guides/web-apis.md
+++ b/guides/web-apis.md
@@ -2,8 +2,7 @@
 
 > **Audience:** Haskell developers choosing an HTTP stack for a new service or web application  
 > **Goal:** choose the right level of abstraction and understand the trade-offs before committing to a framework  
-> **Evidence collected:** 2026-08-02  
-> **Human review:** pending  
+> **Last reviewed:** 2026-08-02  
 > **Scope:** Scotty, Servant, Yesod, IHP, and the WAI/Warp foundation
 
 ## Start with the application shape
@@ -311,7 +310,7 @@ curl http://localhost:3000/hello/Ada
 - [Hackage Web category](https://hackage.haskell.org/packages/#cat:Web)
 - [Legacy Awesome Haskell Web section](../README.md#web)
 
-## Evidence collected
+## Sources
 
 - [Scotty package documentation](https://hackage.haskell.org/package/scotty)
 - [Servant server package documentation](https://hackage.haskell.org/package/servant-server)
@@ -324,6 +323,6 @@ curl http://localhost:3000/hello/Ada
 - [wai-extra package documentation](https://hackage.haskell.org/package/wai-extra)
 - [Awesome Haskell example CI](https://github.com/krispo/awesome-haskell/actions)
 
-## Editorial review notes
+## Review notes
 
-This is a draft awaiting human editorial review. It recommends frameworks only for defined application shapes. After review, it should be checked again when framework APIs, compiler compatibility, platform assumptions, or maintenance status change. Database-library choices belong in the separate database pilot rather than being inferred from the web framework alone.
+This guide recommends frameworks only for defined application shapes. Check it again when framework APIs, compiler compatibility, platform assumptions, or maintenance status change. Database-library choices belong in the separate database pilot rather than being inferred from the web framework alone.

--- a/guides/web-apis.md
+++ b/guides/web-apis.md
@@ -1,52 +1,48 @@
 # Building web APIs in Haskell
 
 > **Audience:** Haskell developers choosing an HTTP stack for a new service or web application  
-> **Goal:** choose an appropriate level of abstraction and understand the trade-offs before committing to a framework  
+> **Goal:** choose the right level of abstraction and understand the trade-offs before committing to a framework  
 > **Last reviewed:** 2026-08-02  
-> **Review scope:** Scotty, Servant, Yesod, IHP, and the WAI/Warp foundation; database libraries and deployment platforms are covered only where they affect the framework choice
+> **Review scope:** Scotty, Servant, Yesod, IHP, and the WAI/Warp foundation
 
-## Start with the shape of the application
+## Start with the application shape
 
-There is no single best Haskell web framework. The useful first question is not “Which framework is most popular?” but “What kind of application are we building?”
+There is no single best Haskell web framework. Start with the kind of application being built.
 
 | Need | Starting point | Why |
 | --- | --- | --- |
-| A small JSON service, webhook receiver, prototype, or first Haskell API | **Scotty** | Direct routing model, low ceremony, standard WAI application underneath |
-| A contract-heavy API with many typed endpoints or shared client/server definitions | **Servant** | API structure is represented at the type level and interpreted by server/client tooling |
-| A server-rendered application with routing, forms, sessions, authentication, and database integration | **Yesod** | Cohesive full-stack framework with typed routes and established application structure |
-| A rapid full-stack product built around PostgreSQL, Nix, generated code, and integrated tooling | **IHP** | Opinionated development environment and framework designed as one platform |
-| Custom middleware, framework internals, gateways, or a deliberately minimal HTTP layer | **WAI + Warp** | Maximum control over the common Haskell web application interface |
+| Small JSON service, webhook receiver, prototype, or first Haskell API | **Scotty** | Direct routes, low ceremony, and a standard WAI application underneath |
+| Contract-heavy API with many typed endpoints or shared client/server definitions | **Servant** | The API structure is represented at the type level and interpreted by tooling |
+| Server-rendered application with forms, sessions, authentication, and database integration | **Yesod** | Cohesive full-stack framework with typed routes and an established application structure |
+| Rapid full-stack product built around PostgreSQL, Nix, generated code, and integrated tooling | **IHP** | Opinionated framework and development environment designed as one platform |
+| Middleware, gateways, framework internals, or a deliberately minimal HTTP layer | **WAI + Warp** | Direct control over the common Haskell web application interface |
 
-The default runnable example in this repository uses **Scotty** because it exposes the HTTP concepts clearly without requiring type-level API definitions or a full application platform. That is a teaching default, not a recommendation to replace Servant, Yesod, or IHP in their stronger use cases.
+The runnable example in this repository uses Scotty because it exposes HTTP concepts without requiring type-level API definitions or a full application platform. That is a teaching default, not a universal ranking.
 
 ## The shared foundation: WAI and Warp
 
-**WAI** is the common application interface used by much of the Haskell web ecosystem. A WAI `Application` receives a request and produces a response. Middleware can wrap an application to provide logging, authentication, compression, request limits, metrics, or other cross-cutting behavior.
+**WAI** is the application interface used by much of the Haskell web ecosystem. A WAI `Application` receives a request and produces a response. Middleware can wrap it to provide logging, authentication, compression, request limits, metrics, or other cross-cutting behavior.
 
-**Warp** is a production-oriented HTTP server for WAI applications. Frameworks such as Scotty and Yesod commonly produce WAI applications and run them with Warp.
-
-This shared layer matters because choosing a framework does not necessarily isolate a project from the rest of the ecosystem. WAI middleware and WAI testing tools can often be reused across frameworks.
+**Warp** is an HTTP server for WAI applications. Scotty and Yesod can produce WAI applications and commonly run them with Warp.
 
 Use WAI directly when:
 
 - building middleware or infrastructure rather than ordinary business routes;
-- exact control over request and response handling is important;
-- integrating several independently produced WAI applications;
-- framework abstractions would hide the behavior being implemented.
+- exact request and response control is important;
+- combining several independently produced WAI applications;
+- a framework abstraction would hide the behavior being implemented.
 
 Trade-offs:
 
-- routing, parameter decoding, error conventions, JSON handling, and application structure become the project's responsibility;
-- low-level flexibility can turn into locally invented framework code;
-- teams must establish conventions that a higher-level framework would otherwise provide.
+- routing, parameter decoding, errors, JSON conventions, and structure become project responsibilities;
+- flexibility can turn into a locally invented framework;
+- teams must establish conventions that a higher-level framework would otherwise supply.
 
 Direct WAI is a foundation, not an automatic badge of performance or simplicity.
 
 ## Scotty: direct routes with low ceremony
 
 Scotty is inspired by Sinatra and runs on WAI and Warp. Routes are written directly using HTTP verbs and path patterns.
-
-A small API can look like:
 
 ```haskell
 {-# LANGUAGE OverloadedStrings #-}
@@ -68,26 +64,35 @@ main = scotty 3000 $ do
 Use Scotty when:
 
 - the service has a small or medium number of straightforward routes;
-- route behavior is easier to read directly than through a type-level contract;
+- direct route readability matters more than a reusable type-level contract;
 - the team wants to introduce Haskell HTTP development incrementally;
-- the application mainly exposes JSON endpoints, webhooks, health checks, or small internal services;
+- the application mainly exposes JSON endpoints, webhooks, or small internal services;
 - WAI middleware will provide cross-cutting concerns.
 
 Trade-offs:
 
-- endpoint contracts are not represented once as a type-level API shared by servers and clients;
-- large route files require deliberate module structure and conventions;
+- endpoint contracts are not represented once and shared by server and client tooling;
+- large route sets require deliberate module boundaries;
 - request validation, domain errors, authentication policy, and API documentation need explicit design;
-- the concise routing style can encourage handlers to accumulate business logic;
-- default development settings should be reviewed before production deployment.
+- concise handlers can accumulate business logic unless the project keeps them thin;
+- development defaults must be reviewed before production deployment.
 
-Scotty is small, but production responsibility is not small. Keep handlers thin, move domain logic into ordinary modules, define a consistent error format, and test the generated WAI application without binding a real port.
+### Verified compiler compatibility
+
+The repository example uses the released `scotty-0.30` package.
+
+As reviewed on 2026-08-02:
+
+- **GHC 9.12:** dependency resolution, build, and route tests are verified in CI;
+- **GHC 9.14.1:** the released dependency graph does not resolve because Scotty requires `http-api-data < 0.7`, while the matching `http-api-data-0.6.3` declares `base < 4.22`; GHC 9.14.1 provides `base-4.22`.
+
+The project intentionally does not use `allow-newer` to hide this mismatch. A bound override may happen to compile, but it would no longer demonstrate the officially declared package compatibility. This should be reviewed when Scotty or `http-api-data` releases change.
+
+This limitation is evidence about the current released dependency graph, not proof that Scotty's route implementation is fundamentally incompatible with GHC 9.14.
 
 ## Servant: an API described by types
 
-Servant represents an API using type-level combinators. The same API description can drive server routing and, through ecosystem packages, clients, documentation, links, or other interpretations.
-
-A simplified API type looks like:
+Servant represents an API with type-level combinators. The same description can drive server routing and, through additional packages, clients, documentation, links, or other interpretations.
 
 ```haskell
 {-# LANGUAGE DataKinds #-}
@@ -105,101 +110,99 @@ Use Servant when:
 - the API contract is a central design artifact;
 - many endpoints must stay consistent;
 - server and client definitions should share one description;
-- typed captures, query parameters, request bodies, response types, and status codes reduce meaningful ambiguity;
-- the team is comfortable diagnosing type errors involving API combinators.
+- typed captures, query parameters, request bodies, response types, and status codes remove meaningful ambiguity;
+- the team accepts the cost of type-level API errors and abstractions.
 
 Trade-offs:
 
-- type-level APIs have a real learning and error-message cost;
-- authentication, versioning, custom errors, streaming, and unusual protocol behavior can require advanced combinators or context machinery;
-- generated clients and documentation depend on additional packages whose compatibility must be reviewed;
-- a large API type can become difficult to navigate without named sub-APIs and module boundaries;
-- representing something in the type does not guarantee that the business semantics are correct.
+- type-level APIs have a real learning and diagnostic cost;
+- authentication, custom errors, streaming, and unusual protocol behavior can require advanced machinery;
+- clients and documentation require additional packages whose compatibility must be reviewed;
+- a large API type becomes difficult to navigate without named sub-APIs and modules;
+- compile-time endpoint structure does not prove that business semantics are correct.
 
-Do not choose Servant merely to make an API “more typed.” Choose it when a reusable, inspectable endpoint contract provides concrete value.
+Choose Servant when contract reuse creates concrete value, not merely because it is “more typed.”
 
 ## Yesod: a cohesive full-stack framework
 
-Yesod is designed for type-safe, RESTful web applications and includes established approaches to routing, handlers, templates, forms, sessions, authentication, authorization, persistence, and deployment.
+Yesod provides established approaches to typed routing, handlers, templates, forms, sessions, authentication, authorization, persistence, and deployment.
 
 Use Yesod when:
 
 - the product is a complete web application rather than only a small JSON service;
 - server-rendered HTML, forms, sessions, and authentication are first-class requirements;
-- typed routes should be used throughout templates and application code;
-- the team values a cohesive application architecture;
-- the existing Yesod and Persistent ecosystem fits the domain.
+- typed routes should be used across templates and application code;
+- the team values a cohesive framework architecture;
+- the Yesod and Persistent ecosystem fits the project.
 
 Trade-offs:
 
-- Template Haskell, quasiquoters, generated routes, and Yesod-specific monads increase the conceptual surface;
-- the application structure is more framework-shaped than a small WAI or Scotty service;
-- using only a narrow subset of the framework may not justify adopting the whole stack;
-- teams building API-only services may prefer the smaller mental model of Scotty or the explicit contract model of Servant.
+- Template Haskell, quasiquoters, generated routes, and framework-specific monads increase the conceptual surface;
+- the application is more framework-shaped than a small WAI or Scotty service;
+- adopting the whole stack may be excessive for an API-only service;
+- teams may prefer Scotty's direct routes or Servant's explicit contract model.
 
-Yesod remains relevant for full applications even when it is not the default recommendation for a minimal JSON API.
+## IHP: an integrated product platform
 
-## IHP: an integrated product-development platform
-
-IHP combines a Haskell web framework with a managed Nix development environment, PostgreSQL tooling, schema and code generation, routing, controllers, views, authentication, live reload, deployment guidance, and other product-oriented features.
+IHP combines a web framework with a managed Nix environment, PostgreSQL tooling, schema and code generation, routing, controllers, views, authentication, live reload, and deployment guidance.
 
 Use IHP when:
 
 - rapid development of a database-backed web product is the primary goal;
-- the team accepts PostgreSQL and Nix as central parts of the development model;
-- integrated generators, conventions, live reload, and framework tooling reduce more work than they introduce;
-- HTML applications and JSON APIs are both required;
+- PostgreSQL and Nix fit the team's operating model;
+- integrated generators and conventions remove more work than they introduce;
+- HTML applications and JSON endpoints are both required;
 - a cohesive platform is preferred over assembling independent libraries.
 
 Trade-offs:
 
-- IHP is substantially more opinionated than a library-oriented stack;
-- Nix, generated code, framework conventions, and the IHP development server become part of the team's operating model;
-- adopting only one isolated component is less natural than adopting the platform;
-- migration away from integrated framework conventions may cost more than migration from a small routing library.
+- IHP is substantially more opinionated than a routing library;
+- Nix, generated code, and IHP conventions become part of the development model;
+- adopting one isolated component is less natural than adopting the platform;
+- migration away from integrated conventions may cost more than migration from a small library stack.
 
-IHP should be evaluated as a platform decision, not as another interchangeable routing package.
+Evaluate IHP as a platform decision, not as an interchangeable router.
 
-## Framework choice by pressure
+## Choose by the dominant pressure
 
 ### Choose Scotty when clarity and iteration speed dominate
 
-Typical examples:
+Typical cases:
 
 - webhook receiver;
 - internal JSON service;
 - small public API;
-- health and administration service;
+- health or administration service;
 - prototype whose domain logic already lives in ordinary Haskell modules.
 
 ### Choose Servant when contract reuse dominates
 
-Typical examples:
+Typical cases:
 
 - many endpoints with shared request and response types;
 - generated internal clients;
-- APIs maintained by multiple teams;
-- services where endpoint changes should cause compile-time work in dependent code;
-- a public API with carefully modeled status codes and content types.
+- APIs maintained by several teams;
+- services where endpoint changes should force dependent code to adapt;
+- public APIs with carefully modeled content types and status codes.
 
 ### Choose Yesod or IHP when application features dominate
 
-Typical examples:
+Typical cases:
 
-- server-rendered product;
-- authentication-heavy business application;
-- forms, sessions, user-facing pages, and database-backed workflows;
-- a team that benefits from framework conventions more than from independent package choice.
+- server-rendered products;
+- authentication-heavy business applications;
+- forms, sessions, user pages, and database-backed workflows;
+- teams that benefit from framework conventions more than independent package choice.
 
 ### Choose WAI directly when infrastructure behavior dominates
 
-Typical examples:
+Typical cases:
 
 - middleware;
-- reverse proxy or gateway components;
-- protocol adapters;
+- gateways and protocol adapters;
+- framework integration code;
 - custom routing experiments;
-- framework or server integration code.
+- server infrastructure.
 
 ## Production concerns the framework does not remove
 
@@ -211,54 +214,54 @@ Every stack still needs explicit decisions about:
 - timeouts and request-size limits;
 - graceful shutdown;
 - authentication and authorization;
-- CORS and proxy headers;
+- CORS and trusted proxy headers;
 - error response shape;
-- database pool sizing and migrations;
-- dependency updates and security review;
+- database pooling and migrations;
+- dependency and security updates;
 - deployment, health checks, and rollback.
 
-A framework may provide hooks or packages for these concerns, but installing a framework does not settle the policy.
+A framework may provide hooks or packages, but installing it does not define the policy.
 
 ## Keep handlers thin
 
-Regardless of framework, prefer this direction:
+Prefer this direction in every framework:
 
 ```text
 HTTP request
     ↓
 parse and validate transport data
     ↓
-call domain/application function
+call a domain or application function
     ↓
-translate domain result into HTTP response
+translate the result into an HTTP response
 ```
 
-Avoid placing database queries, authorization rules, serialization details, and domain transitions in one route handler. Thin boundaries make framework migration less important and tests more focused.
+Avoid combining database access, authorization rules, serialization, and domain transitions in one route handler. Thin boundaries make tests clearer and framework migration less important.
 
 ## Testing web applications
 
-Prefer testing the generated WAI application directly before relying on process-level tests.
+Test the generated WAI application directly before relying on process-level tests.
 
-A useful test stack includes:
+A useful stack includes:
 
-- route tests that issue requests to a WAI `Application`;
-- JSON body and status assertions;
-- unit and property tests for pure domain logic;
+- route tests issuing requests to a WAI `Application`;
+- body, header, and status assertions;
+- unit and property tests for domain logic;
 - integration tests for real database behavior;
 - a small number of process-level smoke tests when startup configuration matters.
 
-The repository example uses `Network.Wai.Test` from `wai-extra`, so CI can exercise routes without opening a network port.
+The repository example uses `Network.Wai.Test`, allowing CI to exercise routes without opening a port.
 
 ## Runnable example
 
 [`examples/web-api-scotty`](../examples/web-api-scotty) demonstrates:
 
-- a small Scotty route definition;
+- Scotty route definitions;
 - JSON responses with Aeson;
 - a health endpoint and path capture;
 - conversion to a WAI `Application`;
 - in-process route tests with Tasty and `Network.Wai.Test`;
-- CI builds and tests on GHC 9.12 and 9.14.
+- verified builds and tests on GHC 9.12.
 
 Run it with:
 
@@ -279,8 +282,8 @@ curl http://localhost:3000/hello/Ada
 
 | Decision | Starting recommendation | Consider an alternative when |
 | --- | --- | --- |
-| First small JSON API | Scotty | Contract reuse or full-stack features dominate |
-| Contract-heavy service | Servant | Direct route readability is more valuable than type-level interpretation |
+| First small JSON API | Scotty | Contract reuse, current compiler compatibility, or full-stack features dominate |
+| Contract-heavy service | Servant | Direct route readability matters more than type-level interpretation |
 | Full-stack server-rendered application | Yesod | The team wants IHP's integrated platform or a smaller library stack |
 | Integrated PostgreSQL product platform | IHP | Nix, code generation, and strong conventions do not fit the team |
 | HTTP foundation or middleware | WAI + Warp | Ordinary application routing would benefit from a framework |
@@ -318,7 +321,8 @@ curl http://localhost:3000/hello/Ada
 - [WAI package documentation](https://hackage.haskell.org/package/wai)
 - [Warp package documentation](https://hackage.haskell.org/package/warp)
 - [wai-extra package documentation](https://hackage.haskell.org/package/wai-extra)
+- [Awesome Haskell example CI](https://github.com/krispo/awesome-haskell/actions)
 
 ## Review notes
 
-This guide intentionally recommends frameworks only for defined application shapes. It should be reviewed when framework APIs, compiler compatibility, platform assumptions, or maintenance status change. Database-library choices will be handled in the separate database pilot rather than being inferred from the web framework alone.
+This guide recommends frameworks only for defined application shapes. Review it when framework APIs, compiler compatibility, platform assumptions, or maintenance status change. Database-library choices belong in the separate database pilot rather than being inferred from the web framework alone.

--- a/guides/web-apis.md
+++ b/guides/web-apis.md
@@ -1,0 +1,324 @@
+# Building web APIs in Haskell
+
+> **Audience:** Haskell developers choosing an HTTP stack for a new service or web application  
+> **Goal:** choose an appropriate level of abstraction and understand the trade-offs before committing to a framework  
+> **Last reviewed:** 2026-08-02  
+> **Review scope:** Scotty, Servant, Yesod, IHP, and the WAI/Warp foundation; database libraries and deployment platforms are covered only where they affect the framework choice
+
+## Start with the shape of the application
+
+There is no single best Haskell web framework. The useful first question is not “Which framework is most popular?” but “What kind of application are we building?”
+
+| Need | Starting point | Why |
+| --- | --- | --- |
+| A small JSON service, webhook receiver, prototype, or first Haskell API | **Scotty** | Direct routing model, low ceremony, standard WAI application underneath |
+| A contract-heavy API with many typed endpoints or shared client/server definitions | **Servant** | API structure is represented at the type level and interpreted by server/client tooling |
+| A server-rendered application with routing, forms, sessions, authentication, and database integration | **Yesod** | Cohesive full-stack framework with typed routes and established application structure |
+| A rapid full-stack product built around PostgreSQL, Nix, generated code, and integrated tooling | **IHP** | Opinionated development environment and framework designed as one platform |
+| Custom middleware, framework internals, gateways, or a deliberately minimal HTTP layer | **WAI + Warp** | Maximum control over the common Haskell web application interface |
+
+The default runnable example in this repository uses **Scotty** because it exposes the HTTP concepts clearly without requiring type-level API definitions or a full application platform. That is a teaching default, not a recommendation to replace Servant, Yesod, or IHP in their stronger use cases.
+
+## The shared foundation: WAI and Warp
+
+**WAI** is the common application interface used by much of the Haskell web ecosystem. A WAI `Application` receives a request and produces a response. Middleware can wrap an application to provide logging, authentication, compression, request limits, metrics, or other cross-cutting behavior.
+
+**Warp** is a production-oriented HTTP server for WAI applications. Frameworks such as Scotty and Yesod commonly produce WAI applications and run them with Warp.
+
+This shared layer matters because choosing a framework does not necessarily isolate a project from the rest of the ecosystem. WAI middleware and WAI testing tools can often be reused across frameworks.
+
+Use WAI directly when:
+
+- building middleware or infrastructure rather than ordinary business routes;
+- exact control over request and response handling is important;
+- integrating several independently produced WAI applications;
+- framework abstractions would hide the behavior being implemented.
+
+Trade-offs:
+
+- routing, parameter decoding, error conventions, JSON handling, and application structure become the project's responsibility;
+- low-level flexibility can turn into locally invented framework code;
+- teams must establish conventions that a higher-level framework would otherwise provide.
+
+Direct WAI is a foundation, not an automatic badge of performance or simplicity.
+
+## Scotty: direct routes with low ceremony
+
+Scotty is inspired by Sinatra and runs on WAI and Warp. Routes are written directly using HTTP verbs and path patterns.
+
+A small API can look like:
+
+```haskell
+{-# LANGUAGE OverloadedStrings #-}
+
+import Data.Aeson (object, (.=))
+import Data.Text (Text)
+import Web.Scotty (get, json, pathParam, scotty)
+
+main :: IO ()
+main = scotty 3000 $ do
+  get "/health" $
+    json (object ["status" .= ("ok" :: Text)])
+
+  get "/hello/:name" $ do
+    name <- pathParam "name"
+    json (object ["message" .= ("Hello, " <> (name :: Text) <> "!")])
+```
+
+Use Scotty when:
+
+- the service has a small or medium number of straightforward routes;
+- route behavior is easier to read directly than through a type-level contract;
+- the team wants to introduce Haskell HTTP development incrementally;
+- the application mainly exposes JSON endpoints, webhooks, health checks, or small internal services;
+- WAI middleware will provide cross-cutting concerns.
+
+Trade-offs:
+
+- endpoint contracts are not represented once as a type-level API shared by servers and clients;
+- large route files require deliberate module structure and conventions;
+- request validation, domain errors, authentication policy, and API documentation need explicit design;
+- the concise routing style can encourage handlers to accumulate business logic;
+- default development settings should be reviewed before production deployment.
+
+Scotty is small, but production responsibility is not small. Keep handlers thin, move domain logic into ordinary modules, define a consistent error format, and test the generated WAI application without binding a real port.
+
+## Servant: an API described by types
+
+Servant represents an API using type-level combinators. The same API description can drive server routing and, through ecosystem packages, clients, documentation, links, or other interpretations.
+
+A simplified API type looks like:
+
+```haskell
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeOperators #-}
+
+import Servant
+
+type API =
+       "health" :> Get '[JSON] Health
+  :<|> "hello" :> Capture "name" Text :> Get '[JSON] Greeting
+```
+
+Use Servant when:
+
+- the API contract is a central design artifact;
+- many endpoints must stay consistent;
+- server and client definitions should share one description;
+- typed captures, query parameters, request bodies, response types, and status codes reduce meaningful ambiguity;
+- the team is comfortable diagnosing type errors involving API combinators.
+
+Trade-offs:
+
+- type-level APIs have a real learning and error-message cost;
+- authentication, versioning, custom errors, streaming, and unusual protocol behavior can require advanced combinators or context machinery;
+- generated clients and documentation depend on additional packages whose compatibility must be reviewed;
+- a large API type can become difficult to navigate without named sub-APIs and module boundaries;
+- representing something in the type does not guarantee that the business semantics are correct.
+
+Do not choose Servant merely to make an API “more typed.” Choose it when a reusable, inspectable endpoint contract provides concrete value.
+
+## Yesod: a cohesive full-stack framework
+
+Yesod is designed for type-safe, RESTful web applications and includes established approaches to routing, handlers, templates, forms, sessions, authentication, authorization, persistence, and deployment.
+
+Use Yesod when:
+
+- the product is a complete web application rather than only a small JSON service;
+- server-rendered HTML, forms, sessions, and authentication are first-class requirements;
+- typed routes should be used throughout templates and application code;
+- the team values a cohesive application architecture;
+- the existing Yesod and Persistent ecosystem fits the domain.
+
+Trade-offs:
+
+- Template Haskell, quasiquoters, generated routes, and Yesod-specific monads increase the conceptual surface;
+- the application structure is more framework-shaped than a small WAI or Scotty service;
+- using only a narrow subset of the framework may not justify adopting the whole stack;
+- teams building API-only services may prefer the smaller mental model of Scotty or the explicit contract model of Servant.
+
+Yesod remains relevant for full applications even when it is not the default recommendation for a minimal JSON API.
+
+## IHP: an integrated product-development platform
+
+IHP combines a Haskell web framework with a managed Nix development environment, PostgreSQL tooling, schema and code generation, routing, controllers, views, authentication, live reload, deployment guidance, and other product-oriented features.
+
+Use IHP when:
+
+- rapid development of a database-backed web product is the primary goal;
+- the team accepts PostgreSQL and Nix as central parts of the development model;
+- integrated generators, conventions, live reload, and framework tooling reduce more work than they introduce;
+- HTML applications and JSON APIs are both required;
+- a cohesive platform is preferred over assembling independent libraries.
+
+Trade-offs:
+
+- IHP is substantially more opinionated than a library-oriented stack;
+- Nix, generated code, framework conventions, and the IHP development server become part of the team's operating model;
+- adopting only one isolated component is less natural than adopting the platform;
+- migration away from integrated framework conventions may cost more than migration from a small routing library.
+
+IHP should be evaluated as a platform decision, not as another interchangeable routing package.
+
+## Framework choice by pressure
+
+### Choose Scotty when clarity and iteration speed dominate
+
+Typical examples:
+
+- webhook receiver;
+- internal JSON service;
+- small public API;
+- health and administration service;
+- prototype whose domain logic already lives in ordinary Haskell modules.
+
+### Choose Servant when contract reuse dominates
+
+Typical examples:
+
+- many endpoints with shared request and response types;
+- generated internal clients;
+- APIs maintained by multiple teams;
+- services where endpoint changes should cause compile-time work in dependent code;
+- a public API with carefully modeled status codes and content types.
+
+### Choose Yesod or IHP when application features dominate
+
+Typical examples:
+
+- server-rendered product;
+- authentication-heavy business application;
+- forms, sessions, user-facing pages, and database-backed workflows;
+- a team that benefits from framework conventions more than from independent package choice.
+
+### Choose WAI directly when infrastructure behavior dominates
+
+Typical examples:
+
+- middleware;
+- reverse proxy or gateway components;
+- protocol adapters;
+- custom routing experiments;
+- framework or server integration code.
+
+## Production concerns the framework does not remove
+
+Every stack still needs explicit decisions about:
+
+- configuration and secrets;
+- structured logging and request identifiers;
+- metrics and tracing;
+- timeouts and request-size limits;
+- graceful shutdown;
+- authentication and authorization;
+- CORS and proxy headers;
+- error response shape;
+- database pool sizing and migrations;
+- dependency updates and security review;
+- deployment, health checks, and rollback.
+
+A framework may provide hooks or packages for these concerns, but installing a framework does not settle the policy.
+
+## Keep handlers thin
+
+Regardless of framework, prefer this direction:
+
+```text
+HTTP request
+    ↓
+parse and validate transport data
+    ↓
+call domain/application function
+    ↓
+translate domain result into HTTP response
+```
+
+Avoid placing database queries, authorization rules, serialization details, and domain transitions in one route handler. Thin boundaries make framework migration less important and tests more focused.
+
+## Testing web applications
+
+Prefer testing the generated WAI application directly before relying on process-level tests.
+
+A useful test stack includes:
+
+- route tests that issue requests to a WAI `Application`;
+- JSON body and status assertions;
+- unit and property tests for pure domain logic;
+- integration tests for real database behavior;
+- a small number of process-level smoke tests when startup configuration matters.
+
+The repository example uses `Network.Wai.Test` from `wai-extra`, so CI can exercise routes without opening a network port.
+
+## Runnable example
+
+[`examples/web-api-scotty`](../examples/web-api-scotty) demonstrates:
+
+- a small Scotty route definition;
+- JSON responses with Aeson;
+- a health endpoint and path capture;
+- conversion to a WAI `Application`;
+- in-process route tests with Tasty and `Network.Wai.Test`;
+- CI builds and tests on GHC 9.12 and 9.14.
+
+Run it with:
+
+```sh
+cd examples/web-api-scotty
+cabal test all --test-show-details=direct
+cabal run web-api-scotty
+```
+
+Then, in another terminal:
+
+```sh
+curl http://localhost:3000/health
+curl http://localhost:3000/hello/Ada
+```
+
+## Decision record
+
+| Decision | Starting recommendation | Consider an alternative when |
+| --- | --- | --- |
+| First small JSON API | Scotty | Contract reuse or full-stack features dominate |
+| Contract-heavy service | Servant | Direct route readability is more valuable than type-level interpretation |
+| Full-stack server-rendered application | Yesod | The team wants IHP's integrated platform or a smaller library stack |
+| Integrated PostgreSQL product platform | IHP | Nix, code generation, and strong conventions do not fit the team |
+| HTTP foundation or middleware | WAI + Warp | Ordinary application routing would benefit from a framework |
+
+## Explore the ecosystem
+
+### Frameworks and API libraries
+
+- [Scotty](https://hackage.haskell.org/package/scotty)
+- [Servant documentation](https://docs.servant.dev/)
+- [servant-server](https://hackage.haskell.org/package/servant-server)
+- [Yesod](https://www.yesodweb.com/)
+- [Yesod book](https://www.yesodweb.com/book)
+- [IHP guide](https://ihp.digitallyinduced.com/Guide/)
+
+### Foundation and middleware
+
+- [WAI](https://hackage.haskell.org/package/wai)
+- [Warp](https://hackage.haskell.org/package/warp)
+- [wai-extra](https://hackage.haskell.org/package/wai-extra)
+
+### Broader discovery
+
+- [Hackage Web category](https://hackage.haskell.org/packages/#cat:Web)
+- [Legacy Awesome Haskell Web section](../README.md#web)
+
+## Evidence used for this review
+
+- [Scotty package documentation](https://hackage.haskell.org/package/scotty)
+- [Servant server package documentation](https://hackage.haskell.org/package/servant-server)
+- [Servant tutorial](https://docs.servant.dev/en/stable/tutorial/index.html)
+- [Yesod book](https://www.yesodweb.com/book)
+- [yesod-core package documentation](https://hackage.haskell.org/package/yesod-core)
+- [IHP guide](https://ihp.digitallyinduced.com/Guide/)
+- [WAI package documentation](https://hackage.haskell.org/package/wai)
+- [Warp package documentation](https://hackage.haskell.org/package/warp)
+- [wai-extra package documentation](https://hackage.haskell.org/package/wai-extra)
+
+## Review notes
+
+This guide intentionally recommends frameworks only for defined application shapes. It should be reviewed when framework APIs, compiler compatibility, platform assumptions, or maintenance status change. Database-library choices will be handled in the separate database pilot rather than being inferred from the web framework alone.


### PR DESCRIPTION
## Summary

This draft adds the Web APIs pilot area for the Awesome Haskell redesign.

## Included

- `guides/web-apis.md` with a task-oriented comparison of:
  - Scotty;
  - Servant;
  - Yesod;
  - IHP;
  - WAI and Warp;
- `examples/web-api-scotty` as a small JSON API;
- in-process route tests through `Network.Wai.Test`;
- CI verification for the released Scotty dependency graph;
- a streamlined `README.next.md` linking the three completed pilot routes.

## Decision model

The guide does not declare one universal winner:

- Scotty for a small JSON service or first Haskell API;
- Servant when a reusable typed API contract provides concrete value;
- Yesod for a cohesive full-stack web application;
- IHP for an integrated PostgreSQL/Nix product platform;
- WAI and Warp for middleware and low-level infrastructure.

## Verification

The Scotty example passes the complete required job on GHC 9.12.4:

- dependency resolution passed;
- the library, executable, and test suite built successfully;
- the health, path-parameter, and unknown-route tests passed through `Network.Wai.Test`.

CI initially caught a missing direct `text` dependency in the test suite. The Cabal manifest was corrected rather than relying on a transitive dependency.

## Compatibility finding

The first CI matrix intentionally tested the example against GHC 9.12 and GHC 9.14.1.

- GHC 9.12 resolves the released dependency graph and is the supported verification target for this example.
- GHC 9.14.1 cannot currently resolve it: `scotty-0.30` requires `http-api-data < 0.7`, while `http-api-data-0.6.3` declares `base < 4.22`; GHC 9.14.1 provides `base-4.22`.

The workflow does not use `allow-newer` to hide the mismatch. The limitation is documented in the guide and example README and should be checked again after future Scotty or `http-api-data` releases.

## Structured data

No new YAML recommendation records are included in this PR. Web API records can be added in a follow-up after the category fields are finalized.

## Checklist

- [x] Add the web API decision guide
- [x] Add a runnable Scotty example
- [x] Test routes through a WAI application without opening a port
- [x] Link the guide and example from `README.next.md`
- [x] Investigate GHC 9.14 compatibility without forcing bounds
- [x] Document the released dependency limitation
- [x] Confirm the GHC 9.12 build and route tests complete successfully
- [x] Fix direct test-suite dependency declarations found by CI