### PR TITLE
Simplify structured entry review metadata

### DIFF
--- a/CONTRIBUTING.next.md
+++ b/CONTRIBUTING.next.md
@@ -41,7 +41,7 @@ A reviewed recommendation uses a higher standard. It should answer:
 - What are its important trade-offs?
 - Which nearby alternatives were considered?
 - What current evidence supports the recommendation?
-- When was the entry reviewed?
+- When were the entry's claims and sources checked?
 
 A recommendation should normally include at least one limitation. A contribution that only lists advantages is incomplete.
 
@@ -81,15 +81,15 @@ The working vocabulary is:
 
 Recommendation level is separate from maintenance status. For example, a stable project can be either recommended or discovery-only.
 
-## Review dates
+## Check dates
 
-Reviewed guidance must include a `last_reviewed` date in ISO format:
+Structured entries must include a `checked_on` date in ISO format:
 
 ```text
 YYYY-MM-DD
 ```
 
-A review date means that a contributor inspected the cited evidence on that date. It does not guarantee future compatibility.
+The date means that the entry's claims and cited evidence were inspected on that date. It does not guarantee future compatibility.
 
 ## Runnable examples
 
@@ -119,7 +119,7 @@ Contributors must disclose when they are:
 - selling services primarily based on the project;
 - otherwise likely to benefit from its inclusion.
 
-Affiliation does not disqualify a contribution. Hidden affiliation damages trust.
+Affiliation does not disqualify a contribution. Hidden affiliation damages trust. Disclose it in the Pull Request description or discussion; contributor identity is not duplicated inside each YAML entry.
 
 ## Writing style
 
@@ -142,7 +142,7 @@ For a discovery entry:
 - [ ] The link is canonical and works.
 - [ ] The description is neutral and specific.
 - [ ] The category is appropriate.
-- [ ] Affiliation is disclosed.
+- [ ] Affiliation is disclosed in the Pull Request when relevant.
 
 For a reviewed recommendation:
 
@@ -151,8 +151,8 @@ For a reviewed recommendation:
 - [ ] Alternatives are named.
 - [ ] Maintenance or stability claims have evidence.
 - [ ] Primary sources are included where available.
-- [ ] `last_reviewed` is present.
-- [ ] Affiliation is disclosed.
+- [ ] `checked_on` is present.
+- [ ] Affiliation is disclosed in the Pull Request when relevant.
 - [ ] Any runnable example builds and passes CI.
 
 ## Scope control

--- a/VISION.md
+++ b/VISION.md
@@ -82,7 +82,7 @@ Useful evidence may include:
 - runnable examples;
 - CI verification;
 - primary-source production reports;
-- a visible `last reviewed` date.
+- a visible `checked on` date.
 
 Automated signals must support human judgement, not replace it.
 
@@ -90,8 +90,7 @@ Automated signals must support human judgement, not replace it.
 
 Awesome Haskell should provide durable and inspectable evidence that a generated answer usually cannot guarantee:
 
-- recommendations reviewed by identifiable contributors;
-- change history and public discussion;
+- recommendations backed by public change history and discussion;
 - reproducible examples that are compiled in CI;
 - explicit dates and compatibility information;
 - recorded disagreements and trade-offs;
@@ -122,7 +121,7 @@ When maintainership, compatibility, or production readiness is unclear, say so.
 
 ### Make maintenance visible
 
-Important claims should have a review date and, where possible, a source.
+Important claims should have a check date and, where possible, a source.
 
 ### Curate highlights, index the rest
 
@@ -139,17 +138,22 @@ The exact vocabulary may change, but statuses should distinguish at least:
 - **Maintenance mode** — maintained conservatively, with limited new development;
 - **Historical** — important for context but generally not a new-project choice;
 - **Archived** — explicitly discontinued or archived upstream;
-- **Unknown** — not recently reviewed or insufficient evidence.
+- **Unknown** — not recently checked or insufficient evidence.
 
 ## Proposed entry model
 
 A structured entry may eventually contain fields like:
 
 ```yaml
-name: servant
+schema_version: 2
+name: Servant
+kind: package
 category: web-api
+url: https://docs.servant.dev/
 summary: Type-level DSL for describing web APIs.
-status: recommended
+role: recommendation
+recommendation: recommended
+maintenance_status: active
 recommended_for:
   - large typed APIs
   - shared server and client contracts
@@ -159,10 +163,14 @@ consider_alternatives_when:
 tradeoffs:
   - expressive but conceptually demanding
   - compile-time cost can grow with API complexity
-sources:
-  - https://docs.servant.dev/
-last_reviewed: YYYY-MM-DD
-example: examples/web-servant
+alternatives:
+  - Scotty
+  - Yesod
+evidence:
+  - type: official-documentation
+    url: https://docs.servant.dev/
+    supports: typed API descriptions and generated server and client interfaces
+checked_on: YYYY-MM-DD
 ```
 
 The schema must remain practical. We should not collect metadata that nobody can maintain.
@@ -185,7 +193,7 @@ For each pilot area, aim to provide:
 - a curated `Start here` section;
 - comparisons and trade-offs;
 - broader discovery links;
-- project status and review dates;
+- project status and check dates;
 - at least one runnable example where useful.
 
 ## First milestone
@@ -223,7 +231,7 @@ A proposed highlighted recommendation should normally include:
 3. at least one important trade-off;
 4. nearby alternatives;
 5. evidence for maintenance or stability claims;
-6. a review date;
+6. a check date;
 7. disclosure when the contributor is affiliated with the project.
 
 Broad discovery links may use a lighter standard, but they must still be relevant and correctly categorized.
@@ -237,7 +245,7 @@ Possible signals:
 - a newcomer can find a viable starting stack without reading the entire repository;
 - a developer can compare major options in a category;
 - highlighted examples continue to build in CI;
-- stale recommendations are detected and reviewed;
+- stale recommendations are detected and checked;
 - maintainers contribute corrections and trade-offs;
 - other documentation and AI tools can cite or consume the structured data;
 - the number of unexplained links decreases even if the total coverage remains broad.
@@ -249,7 +257,7 @@ Possible signals:
 - Which metadata can be maintained reliably without creating excessive work?
 - Should structured data become the source of truth immediately or only after the pilot categories are validated?
 - How should disputed recommendations be documented?
-- Who should be invited as additional reviewers or maintainers?
+- Who should be invited as additional maintainers or contributors?
 
 ## Working principle
 

--- a/data/testing/hedgehog.yaml
+++ b/data/testing/hedgehog.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 name: Hedgehog
 kind: package
 category: property-testing
@@ -30,6 +30,4 @@ evidence:
   - type: compatibility
     url: https://hackage.haskell.org/package/tasty-hedgehog
     supports: integration with Tasty and compatibility with current Hedgehog and Tasty release ranges
-last_reviewed: 2026-08-02
-reviewers:
-  - krispo
+checked_on: 2026-08-02

--- a/data/testing/hspec.yaml
+++ b/data/testing/hspec.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 name: Hspec
 kind: package
 category: testing
@@ -30,6 +30,4 @@ evidence:
   - type: official-documentation
     url: https://hspec.github.io/quickcheck.html
     supports: direct property-testing integration with QuickCheck
-last_reviewed: 2026-08-02
-reviewers:
-  - krispo
+checked_on: 2026-08-02

--- a/data/testing/quickcheck.yaml
+++ b/data/testing/quickcheck.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 name: QuickCheck
 kind: package
 category: property-testing
@@ -33,6 +33,4 @@ evidence:
   - type: ci
     url: https://github.com/krispo/awesome-haskell/actions
     supports: repository example runs a QuickCheck property through Tasty on GHC 9.12 and 9.14
-last_reviewed: 2026-08-02
-reviewers:
-  - krispo
+checked_on: 2026-08-02

--- a/data/testing/tasty.yaml
+++ b/data/testing/tasty.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 name: Tasty
 kind: package
 category: testing
@@ -29,6 +29,4 @@ evidence:
   - type: ci
     url: https://github.com/krispo/awesome-haskell/actions
     supports: repository example builds and runs a Tasty suite on GHC 9.12 and 9.14
-last_reviewed: 2026-08-02
-reviewers:
-  - krispo
+checked_on: 2026-08-02

--- a/data/toolchain-management/ghcup.yaml
+++ b/data/toolchain-management/ghcup.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 name: GHCup
 kind: project
 category: toolchain-management
@@ -27,6 +27,4 @@ evidence:
   - type: official-documentation
     url: https://www.haskell.org/ghcup/guide/
     supports: recommended and latest release channels plus tool-management behavior
-last_reviewed: 2026-08-02
-reviewers:
-  - krispo
+checked_on: 2026-08-02

--- a/docs/ENTRY_FORMAT.md
+++ b/docs/ENTRY_FORMAT.md
@@ -1,6 +1,6 @@
 # Entry format
 
-> Status: pilot format; expected to change after the first three reviewed categories
+> Status: pilot format; expected to change after the first three checked categories
 
 The structured format exists to make claims inspectable and reusable. It should remain small enough for contributors to maintain by hand.
 
@@ -12,22 +12,22 @@ The format should:
 - separate maintenance status from recommendation level;
 - record important trade-offs;
 - link claims to evidence;
-- expose when a human last reviewed the entry;
+- expose when the entry's claims and sources were last checked;
 - remain readable without a custom application.
 
-The format should not attempt to mirror every field available from GitHub or Hackage.
+The format should not attempt to mirror every field available from GitHub or Hackage. Contributor identity and responsibility already live in Git history and Pull Request discussion, so they are not duplicated in each entry.
 
 ## Minimal discovery entry
 
 ```yaml
-schema_version: 1
+schema_version: 2
 name: Hoogle
 kind: project
 category: api-search
 url: https://hoogle.haskell.org/
 summary: Search Haskell APIs by name or approximate type signature.
 role: discovery
-last_reviewed: 2026-08-02
+checked_on: 2026-08-02
 ```
 
 Required fields for discovery entries:
@@ -39,12 +39,12 @@ Required fields for discovery entries:
 - `url`;
 - `summary`;
 - `role`;
-- `last_reviewed`.
+- `checked_on`.
 
-## Reviewed recommendation entry
+## Recommendation entry
 
 ```yaml
-schema_version: 1
+schema_version: 2
 name: GHCup
 kind: project
 category: toolchain-management
@@ -68,16 +68,16 @@ evidence:
   - type: official-documentation
     url: https://www.haskell.org/ghcup/
     supports: canonical installation and tool-management role
-last_reviewed: 2026-08-02
-reviewers:
-  - krispo
+checked_on: 2026-08-02
 ```
 
 ## Fields
 
 ### `schema_version`
 
-Integer identifying the entry format. The pilot uses `1`.
+Integer identifying the entry format. The current pilot format uses `2`.
+
+Version 2 replaces `last_reviewed` with `checked_on` and removes contributor-specific `reviewers` and `affiliation` metadata from entries.
 
 ### `name`
 
@@ -126,7 +126,7 @@ One neutral sentence describing what the entry is. Do not put recommendation cla
 Either:
 
 - `discovery` — indexed for exploration;
-- `recommendation` — reviewed as a choice for a defined use case.
+- `recommendation` — presented as a choice for a defined use case.
 
 ### `recommendation`
 
@@ -167,7 +167,7 @@ Situations where another option may fit better. This field prevents recommendati
 
 Important costs, limitations, complexity, operational considerations, or compatibility concerns.
 
-At least one trade-off is required for a reviewed recommendation.
+At least one trade-off is required for a recommendation.
 
 ### `alternatives`
 
@@ -194,25 +194,15 @@ Working evidence types:
 - `ci`;
 - `other`.
 
-### `last_reviewed`
+### `checked_on`
 
-ISO date in `YYYY-MM-DD` format. This records human inspection, not automated refresh time.
+ISO date in `YYYY-MM-DD` format. It records when the entry's claims and cited evidence were last checked. It is not an automated refresh timestamp and does not guarantee future compatibility.
 
-### `reviewers`
+## Contributor identity and affiliation
 
-GitHub usernames of contributors who reviewed the recommendation and its evidence.
+Authorship and responsibility are recorded by Git history and Pull Request discussion rather than repeated in every YAML entry.
 
-### `affiliation`
-
-Optional disclosure when a contributor has a relationship with the project.
-
-Example:
-
-```yaml
-affiliation:
-  reviewer: example-user
-  relationship: project maintainer
-```
+Contributors should still disclose relevant project affiliations in the Pull Request description or discussion when an inclusion could create a conflict of interest.
 
 ## What should remain automated
 
@@ -230,13 +220,13 @@ Automation must not independently decide:
 - whether a project is recommended;
 - whether infrequent activity means abandonment;
 - whether one framework is better than another;
-- whether a production claim is credible without reviewing its source.
+- whether a production claim is credible without checking its source.
 
 ## Pilot policy
 
 Do not migrate the entire legacy README into YAML yet.
 
-First create structured entries only for projects discussed in the pilot guides. After three categories have been reviewed, evaluate:
+First create structured entries only for projects discussed in the pilot guides. After three categories have been checked, evaluate:
 
 - which fields contributors actually use;
 - which fields create maintenance burden;

--- a/schema/entry.schema.json
+++ b/schema/entry.schema.json
@@ -12,10 +12,10 @@
     "url",
     "summary",
     "role",
-    "last_reviewed"
+    "checked_on"
   ],
   "properties": {
-    "schema_version": {"const": 1},
+    "schema_version": {"const": 2},
     "name": {"type": "string", "minLength": 1},
     "kind": {
       "enum": [
@@ -88,17 +88,7 @@
         }
       }
     },
-    "last_reviewed": {"type": "string", "format": "date"},
-    "reviewers": {"$ref": "#/$defs/nonEmptyStringList"},
-    "affiliation": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["reviewer", "relationship"],
-      "properties": {
-        "reviewer": {"type": "string", "minLength": 1},
-        "relationship": {"type": "string", "minLength": 1}
-      }
-    }
+    "checked_on": {"type": "string", "format": "date"}
   },
   "allOf": [
     {
@@ -114,8 +104,7 @@
           "consider_alternatives_when",
           "tradeoffs",
           "alternatives",
-          "evidence",
-          "reviewers"
+          "evidence"
         ]
       }
     },


### PR DESCRIPTION
## Summary

Simplify the structured entry format so project metadata describes the project and its evidence without duplicating contributor identity.

## Changes

- rename `last_reviewed` to `checked_on`;
- remove `reviewers` from recommendation entries;
- remove entry-level `affiliation` metadata;
- keep affiliation disclosure in Pull Request discussion;
- bump the structured format from schema version 1 to 2;
- migrate all existing YAML entries;
- update the entry-format, contribution, and vision documentation.

## Rationale

Git history and Pull Request discussion already record authorship and responsibility. `checked_on` records only when the entry's claims and cited evidence were last checked.

## Validation

- [x] Structured-data validation passes on the latest commit
- [x] All existing entries use schema version 2
- [x] No `reviewers` field remains in structured entries
