### PR TITLE
Add structured Web API recommendation records

### DIFF
--- a/data/web-apis/ihp.yaml
+++ b/data/web-apis/ihp.yaml
@@ -1,0 +1,36 @@
+schema_version: 2
+name: IHP
+kind: project
+category: web-api
+url: https://ihp.digitallyinduced.com/Guide/
+summary: Integrated Haskell application platform combining a web framework with PostgreSQL, Nix, generated code, and development tooling.
+role: recommendation
+recommendation: alternative
+maintenance_status: active
+recommended_for:
+  - rapid development of database-backed web products
+  - teams that want PostgreSQL, Nix, generators, routing, views, and authentication as one platform
+  - applications that need both server-rendered HTML and JSON endpoints
+consider_alternatives_when:
+  - Nix and generated code do not fit the team's development model
+  - the project needs only a small routing library or API layer
+  - independent package selection and easier component replacement are priorities
+tradeoffs:
+  - IHP is substantially more opinionated than a routing library
+  - Nix, generated code, PostgreSQL conventions, and IHP project structure become part of the operating model
+  - adopting isolated pieces is less natural than adopting the platform as a whole
+  - migration away from integrated conventions may cost more than migration from a smaller library stack
+alternatives:
+  - Yesod
+  - Scotty
+  - Servant
+  - WAI
+  - Warp
+evidence:
+  - type: official-documentation
+    url: https://ihp.digitallyinduced.com/Guide/
+    supports: integrated Nix environment, PostgreSQL workflow, routing, views, forms, authentication, JSON APIs, and deployment guidance
+  - type: official-documentation
+    url: https://ihp.digitallyinduced.com/api-docs/index.html
+    supports: current public API documentation for the IHP framework packages
+checked_on: 2026-08-03

--- a/data/web-apis/scotty.yaml
+++ b/data/web-apis/scotty.yaml
@@ -1,0 +1,39 @@
+schema_version: 2
+name: Scotty
+kind: package
+category: web-api
+url: https://hackage.haskell.org/package/scotty
+summary: Minimal Haskell web framework with direct routes on top of WAI and Warp.
+role: recommendation
+recommendation: recommended
+maintenance_status: active
+recommended_for:
+  - small JSON services, webhook receivers, and prototypes
+  - first Haskell APIs where direct route definitions reduce setup overhead
+  - services whose domain logic already lives outside HTTP handlers
+consider_alternatives_when:
+  - a shared typed contract must drive servers, clients, or documentation
+  - the application needs an integrated full-stack framework
+  - the project must use GHC 9.14 with only currently declared package bounds
+tradeoffs:
+  - endpoint contracts are not represented once for reuse by server and client tooling
+  - large route sets require deliberate module boundaries and handler conventions
+  - validation, authentication policy, domain errors, and API documentation need explicit design
+  - the released scotty-0.30 dependency graph does not resolve with GHC 9.14.1 without overriding declared bounds
+alternatives:
+  - Servant
+  - Yesod
+  - IHP
+  - WAI
+  - Warp
+evidence:
+  - type: official-documentation
+    url: https://hackage.haskell.org/package/scotty
+    supports: direct route API, WAI application compatibility, and Warp as the default server
+  - type: compatibility
+    url: https://github.com/krispo/awesome-haskell/blob/master/guides/web-apis.md
+    supports: checked GHC 9.12 support and the released dependency-bound limitation on GHC 9.14.1
+  - type: ci
+    url: https://github.com/krispo/awesome-haskell/actions
+    supports: repository example builds and exercises Scotty routes through a WAI application on GHC 9.12
+checked_on: 2026-08-03

--- a/data/web-apis/servant.yaml
+++ b/data/web-apis/servant.yaml
@@ -1,0 +1,36 @@
+schema_version: 2
+name: Servant
+kind: project
+category: web-api
+url: https://docs.servant.dev/
+summary: Family of packages for describing HTTP APIs with type-level combinators and interpreting them as servers and related tooling.
+role: recommendation
+recommendation: alternative
+maintenance_status: active
+recommended_for:
+  - contract-heavy APIs with many typed endpoints
+  - systems that share one API description between servers and generated clients
+  - services where typed captures, request bodies, responses, and status codes remove meaningful ambiguity
+consider_alternatives_when:
+  - a small service benefits more from direct route readability than contract reuse
+  - the team is not prepared for type-level diagnostics and abstractions
+  - server-rendered forms, sessions, and application structure are the dominant requirements
+tradeoffs:
+  - type-level API definitions have a real learning and compiler-diagnostic cost
+  - authentication, custom errors, streaming, and unusual protocol behavior can require advanced machinery
+  - clients, documentation, and other interpretations use additional packages whose compatibility must be managed
+  - large API types need named sub-APIs and module boundaries to remain navigable
+alternatives:
+  - Scotty
+  - Yesod
+  - IHP
+  - WAI
+  - Warp
+evidence:
+  - type: official-documentation
+    url: https://docs.servant.dev/en/stable/tutorial/index.html
+    supports: API-as-a-type model, serving APIs, clients, links, documentation, and authentication
+  - type: official-documentation
+    url: https://hackage.haskell.org/package/servant-server
+    supports: server handlers and routing derived from a Servant API description
+checked_on: 2026-08-03

--- a/data/web-apis/wai.yaml
+++ b/data/web-apis/wai.yaml
@@ -1,0 +1,36 @@
+schema_version: 2
+name: WAI
+kind: package
+category: web-api
+url: https://hackage.haskell.org/package/wai
+summary: Common Haskell web application interface for receiving requests, producing responses, and composing middleware independently of a specific framework or server.
+role: recommendation
+recommendation: recommended
+maintenance_status: stable
+recommended_for:
+  - middleware, gateways, adapters, and framework integration code
+  - applications that need exact request and response control
+  - combining independently produced Haskell web applications behind one interface
+consider_alternatives_when:
+  - ordinary business routes would benefit from framework-provided routing and decoding
+  - a shared typed API contract should drive server and client tooling
+  - forms, sessions, authentication, and full-stack conventions dominate the application
+tradeoffs:
+  - routing, parameter decoding, error conventions, and application structure become project responsibilities
+  - direct use can grow into a locally invented framework without deliberate boundaries
+  - low-level flexibility requires teams to establish conventions supplied by higher-level frameworks
+  - WAI defines the application interface but does not itself provide an HTTP server
+alternatives:
+  - Scotty
+  - Servant
+  - Yesod
+  - IHP
+  - Warp
+evidence:
+  - type: official-documentation
+    url: https://hackage.haskell.org/package/wai
+    supports: the Application request-response interface and interoperability with WAI handlers such as Warp
+  - type: ci
+    url: https://github.com/krispo/awesome-haskell/actions
+    supports: the repository Scotty example is converted to a WAI Application and tested in process
+checked_on: 2026-08-03

--- a/data/web-apis/warp.yaml
+++ b/data/web-apis/warp.yaml
@@ -1,0 +1,35 @@
+schema_version: 2
+name: Warp
+kind: package
+category: web-api
+url: https://hackage.haskell.org/package/warp
+summary: HTTP server for WAI applications with support for HTTP/1.0, HTTP/1.1, and HTTP/2.
+role: recommendation
+recommendation: recommended
+maintenance_status: active
+recommended_for:
+  - running WAI applications as standalone Haskell HTTP services
+  - framework and middleware stacks that expose a WAI Application
+  - services that need configurable server settings without replacing the WAI interface
+consider_alternatives_when:
+  - the deployment platform supplies a different WAI handler or process model
+  - CGI or FastCGI integration is required instead of a standalone HTTP server
+  - the application needs a framework rather than only an HTTP server
+tradeoffs:
+  - Warp does not provide routing, request decoding, authentication, or application structure
+  - TLS termination, trusted proxy handling, timeouts, limits, and shutdown policy still require explicit deployment decisions
+  - low-level server settings must be reviewed against the application's operational requirements
+  - choosing Warp does not remove the need for reverse-proxy and observability design
+alternatives:
+  - warp-tls
+  - wai-handler-fastcgi
+  - platform-provided WAI handler
+  - reverse-proxy-managed application runtime
+evidence:
+  - type: official-documentation
+    url: https://hackage.haskell.org/package/warp
+    supports: Warp's role as a lightweight WAI server and its documented HTTP protocol support
+  - type: ci
+    url: https://github.com/krispo/awesome-haskell/actions
+    supports: the repository Scotty example uses the WAI and Warp-based stack in verified builds
+checked_on: 2026-08-03

--- a/data/web-apis/yesod.yaml
+++ b/data/web-apis/yesod.yaml
@@ -1,0 +1,39 @@
+schema_version: 2
+name: Yesod
+kind: project
+category: web-api
+url: https://www.yesodweb.com/
+summary: Cohesive Haskell web framework with typed routes and established support for handlers, templates, forms, sessions, authentication, and persistence.
+role: recommendation
+recommendation: alternative
+maintenance_status: active
+recommended_for:
+  - server-rendered web applications with forms, sessions, and authentication
+  - teams that want typed routes across handlers, templates, and application code
+  - products that benefit from an established full-stack application structure
+consider_alternatives_when:
+  - the service is primarily a small JSON API with straightforward routes
+  - a reusable type-level API contract is more important than full-stack features
+  - the team prefers assembling independent libraries instead of adopting a cohesive framework
+tradeoffs:
+  - Template Haskell, quasiquoters, generated routes, and framework-specific monads increase the conceptual surface
+  - the framework shapes application structure more strongly than Scotty or direct WAI
+  - adopting the broader stack may be excessive for an API-only service
+  - teams must evaluate how the Yesod and Persistent ecosystems fit their database and deployment choices
+alternatives:
+  - Scotty
+  - Servant
+  - IHP
+  - WAI
+  - Warp
+evidence:
+  - type: official-documentation
+    url: https://www.yesodweb.com/
+    supports: type-safe routing and the framework's integrated web-development approach
+  - type: official-documentation
+    url: https://www.yesodweb.com/book
+    supports: routing, handlers, templates, forms, sessions, persistence, authentication, authorization, and deployment
+  - type: official-documentation
+    url: https://hackage.haskell.org/package/yesod-core
+    supports: core dispatch, handlers, content, JSON, and widget functionality
+checked_on: 2026-08-03


### PR DESCRIPTION
## Summary

Add the structured recommendation records that were intentionally left out of the Web APIs guide PR.

## Included

- Scotty for small JSON services and direct routes;
- Servant for contract-heavy typed APIs;
- Yesod for cohesive full-stack applications;
- IHP for an integrated PostgreSQL and Nix product platform;
- WAI for middleware and low-level application interfaces;
- Warp for serving WAI applications.

## Scope

This PR adds only `data/web-apis/*.yaml` records. It does not change the guide, schema, workflows, or runnable example.

All records use schema version 2 and `checked_on: 2026-08-03`.

## Validation

- [x] Structured-data validation passes on the latest commit
- [x] Each highlighted Web API project has its own record
- [x] Recommendations match the decision model in `guides/web-apis.md`
- [x] Evidence links use official documentation or repository CI
